### PR TITLE
FolderView3 compatibility improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,11 @@
 
 ------------
 
-_The original FolderView project was abandoned. A new fork has taken its place and is under development here: **[Folder.View2](https://github.com/VladoPortos/folder.view2)**_
+Custom CSS styles for use with the **[FolderView3](https://github.com/scolcipitato/folder.view/tree/main)** plugin for **unRAID**.
 
-_I have yet to fully test the custom CSS here with the new Folder.View2 plugin._
+_Requires FolderView3 version **2026.03.23.3** or later._
 
-----------------
-
-_These themes do not currently include styling for VM panel on Dashboard or VM Page._
-
-Custom CSS styles for use with the **[Folder.View](https://github.com/scolcipitato/folder.view/tree/main)** plugin for **unRAID** by **scolcipitato.**
-
-Thanks to scolcipitato for the great plugin! If you have a lot of docker containers, **Folder.View** is a must-have!
+These themes include full styling for **Dashboard**, **Docker page**, and **VM page**, with support for FolderView3's layout modes (classic, accordion, fullwidth, inset, embossed) and preview overflow modes (scroll, expand).
 
 Folder.View plugin **[Support Page](https://forums.unraid.net/topic/142782-plugin-folderview/)** on the unRAID forum.
 
@@ -28,7 +22,7 @@ If you have issues or customization suggestions, contact me on the unRAID forum.
 ## Autostart Icon Customization
 
 Among other basic theme styling, all themes customize the autostart icons on the Dashboard and Docker page. Special icons for autostart containers and the folders that hold autostart containers make it easy to see, at a glance, if all of your autostart containers are running as they should.
-Icons are fully customizable (design, color, and size) via custom properties (variables) in the 06-icons.dashboard.css and 06-icons.docker.css files.
+Icons are fully customizable (design, color, and size) via custom properties (variables) in the 06-icons.dashboard.css and 06-icons.docker-vm.css files.
 
 _See the individual theme README files for more information on that theme._
 

--- a/urblack-theme/01-colors.dashboard-docker-vm.css
+++ b/urblack-theme/01-colors.dashboard-docker-vm.css
@@ -1,5 +1,5 @@
 /*************************************************/
-/* COLOR SCHEME - BASED ON UNRAID STOCK GRAY THEME
+/* COLOR SCHEME - BASED ON UNRAID STOCK BLACK THEME
 Change these settings to your preference */
 /*************************************************/
 /* Look up a hex color convertor online
@@ -7,22 +7,35 @@ like https://htmlcolorcodes.com/color-picker/ */
 /*************************************************/
 :root {
   --cscheme-accent1: #ff8c2f;
-  --cscheme-accent2: #0072c6;
+  --cscheme-accent1-dark: #e07020;
+  --cscheme-accent2: #3e6dba;
   --cscheme-accent3: #4f8a10;
+  --cscheme-accent4: #256f92;
+  --cscheme-accent5: #00BCD4;
+  --cscheme-accent6: #9575CD;
 
-  --cscheme-foreline1: #b0b0b0;
-  --cscheme-foreline2: #9b9b9b;
-  --cscheme-foreline3: #606e7f;
-  --cscheme-foreline4: #606060;
-  --cscheme-backfill1: #323432;
-  --cscheme-backfill2: #1b1d1b;
-  --cscheme-backfill3: #141613;
-  --cscheme-backfill4: #121510;
+  --cscheme-foreline0: #f2f2f2;
+  --cscheme-foreline1: #f2f2f2;
+  --cscheme-foreline1-light: #d0d0d0;
+  --cscheme-foreline1-dark: #8a8a8a;
+  --cscheme-foreline2: #a1a1a1;
+  --cscheme-foreline3: #787878;
+  --cscheme-foreline4: #444444;
+  --cscheme-backfill1: #262626;
+  --cscheme-backfill2: #212121;
+  --cscheme-backfill3: #1c1b1b;
+  --cscheme-backfill4: #191818;
+  --cscheme-cpu: #00BCD4; /* CPU accent color Graph Line */
+  --cscheme-mem: #673AB7; /* Mem accent color Graph Line */
 
   --cscheme-interface-alert: #f0000c;
+  --cscheme-interface-alert2: #fb039a;
   --cscheme-interface-warn: #ff8c2f;
+  --cscheme-interface-warn2: #FFEB3B;
   --cscheme-interface-attention: #d6ff20;
+  --cscheme-interface-attention2: #FFEB3B;
   --cscheme-interface-passed: #4caf50;
+  --cscheme-interface-passed2: #4caf50;
   --cscheme-interface-accent: #2cabe3;
 
   --cscheme-link: #486dba; /* Text links within the docker table */
@@ -31,6 +44,6 @@ like https://htmlcolorcodes.com/color-picker/ */
   --cscheme-tool-linkhov: #2cabe3; /* Container tools - hover */
   --cscheme-cont-update: #ff8c2f; /* Container with update */
   --cscheme-cont-updatehov: #ffc04c; /* Container with update - hover (only in docker table) */
-  --cscheme-folder-update: #0072c6; /* Folder on dashboard with update within */
+  --cscheme-folder-update: #3e6dba; /* Folder on dashboard with update within */
   --cscheme-exfolder-update: #ff8c2f; /* Expanded folder on dashboard with update within */
 }

--- a/urblack-theme/02-vars.dashboard.css
+++ b/urblack-theme/02-vars.dashboard.css
@@ -26,6 +26,9 @@
   --container-logo-saturation: 0; /* Initial color depth for container icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
   --container-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
 
+  /* Override FV3 inset fill to match classic expanded header grey */
+  --fv3-inset-fill: var(--cscheme-foreline4);
+
   /****** EXPANDED FOLDER STYLES ******/
   --exfold-header-brdr-c: var(--cscheme-foreline4); /* Border color for the header */
   --exfold-header-bg-c: var(--cscheme-foreline4); /* Background color for the header */

--- a/urblack-theme/02-vars.docker-vm.css
+++ b/urblack-theme/02-vars.docker-vm.css
@@ -4,15 +4,21 @@
 :root {
   /* Passed/Warning/Green/Orange Text */
   --warn-orange-text-c: var(--cscheme-interface-warn);
-  --pass-green-text-c: var(--cscheme-interface-good);
+  --pass-green-text-c: var(--cscheme-interface-passed);
   --accent-blue-text-c: var(--cscheme-interface-accent);
 
   /* Table Rows */
   --row-base-bg-c: var(--cscheme-backfill4);
   --row-even-bg-c: var(--cscheme-backfill2);
 
+  /* Table Rows VMs Colors */
+  --fv3-row-bg: var(--row-base-bg-c);
+  --fv3-row-alt-bg: var(--row-even-bg-c);
+
   /* Folder Name/Logo Area */
-  --folderbox-width: 250px; /* May need to be increased if --folder-name-text-size is too big */
+  --fv3-folder-name-min-width: 250px;
+  --fv3-folder-name-max-width: none;
+  --folderbox-width: var(--fv3-folder-name-min-width); /* May need to be increased if --folder-name-text-size is too big */
   --folderbox-height: calc(var(--folder-logo-size) + (var(--folderbox-padding-topbottom) * 2) + (var(--folderbox-brdr-width-topbottom) * 2));
   --folderbox-padding-topbottom: 10px;
   --folderbox-padding-leftright: 10px;
@@ -30,6 +36,14 @@
   --folder-name-text-weight: bold;
   --folder-startstop-text-size: 1.2rem; /* 0 to hide */
   --folder-startstop-text-mrgleft: 7px; /* 0 to hide */
+
+  --folder-button-size-hov: 1.08;
+  --folder-button-size-act: 0.98;
+  --folder-button-background: linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1)) 0 0 no-repeat, linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1)) 0 100% no-repeat, linear-gradient(0deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1-dark)) 0 100% no-repeat, linear-gradient(0deg, var(--cscheme-foreline1) 0, var(--cscheme-foreline1)) 100% 100% no-repeat;
+  --folder-button-background-size: 100% 2px, 100% 2px, 2px 100%, 2px 100%;
+  --folder-button-background-hov: linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1));
+  --folder-button-text-c: var(--cscheme-foreline1);
+  --folder-button-text-c-hov: var(--cscheme-foreline0);
 
   /* Folder/Container Preview Row */
   --folderpreview-height: calc(var(--container-logo-size) + (var(--container-logo-mrgtopbottom) * 2) + (var(--folderpreview-brdr-width-topbottom) * 2));

--- a/urblack-theme/03-vars-icons.docker-vm.css
+++ b/urblack-theme/03-vars-icons.docker-vm.css
@@ -1,5 +1,5 @@
 /*************************************************/
-/* VARIABLES FOR ICONS IN DOCKER TABLE - 
+/* VARIABLES FOR ICONS IN DOCKER TABLE -
 Change these settings to your preference */
 /*************************************************/
 /* See https://fontawesome.com/icons for icons.

--- a/urblack-theme/04-dash.dashboard.css
+++ b/urblack-theme/04-dash.dashboard.css
@@ -1,39 +1,54 @@
 /*************************************************/
 /* FOLDER & CONTAINER LOGO ICON HOVER EFFECTS */
 /*************************************************/
+
 /* ALL Folder and Container Icons (also affects expanded header icon) */
-#docker_view .outer img {
+#docker_view .outer img,
+#vm_view .outer img {
   /* Add a transition for smooth scaling */
   transition: transform 0.3s ease;
 }
+
 /* ************ Folder Icon (Compressed Only) ************ */
-#docker_view .outer.folder-docker img {
+#docker_view .outer.folder-docker img,
+#vm_view .outer.folder-vm img {
   /* Default icon size */
   height: var(--folder-logo-size);
   width: var(--folder-logo-size);
-  /* Desaturate docker folder icons */
+  /* Desaturate docker folder icons (Docker & VM) */
   filter: saturate(var(--folder-logo-saturation));
 }
-#docker_view .outer.folder-docker:hover img {
-  /* Saturate docker folder icons */
+
+#docker_view .outer.folder-docker:hover img,
+#vm_view .outer.folder-vm:hover img {
+  /* Saturate docker folder icons (Docker & VM) */
   filter: saturate(var(--folder-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--folder-logo-size-hov));
 }
+
 /* ************ Container Icon ************ */
-#docker_view .outer.folder-element-docker img {
+#docker_view .outer.folder-element-docker img,
+#vm_view .outer.folder-element-vm img {
   /* Default icon size */
   height: var(--container-logo-size);
   width: var(--container-logo-size);
-  /* Desaturate docker container icons */
+  /* Desaturate docker container icons (Docker & VM) */
   filter: saturate(var(--container-logo-saturation));
 }
-#docker_view .outer.folder-element-docker:hover img {
-  /* Saturate docker container icons */
+
+#docker_view .outer.folder-element-docker:hover img,
+#vm_view .outer.folder-element-vm:hover img {
+  /* Saturate docker container icons (Docker & VM) */
   filter: saturate(var(--container-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--container-logo-size-hov));
 }
+
+
+/*************************************************/
+/* SHARED LAYOUT RULES */
+/*************************************************/
 
 /* Apply border-box to all elements inside the docker and vm panes */
 #docker_view *,
@@ -42,19 +57,19 @@
 }
 
 /* Add a padding left to the entire docker and vm icon area
-- this compensates for the expanded folder header */
-#docker_view tr:nth-child(2) td,
-#vm_view tr:nth-child(2) td {
+- this compensates for the expanded folder header (classic only) */
+#docker_view tr:nth-child(2) td.fv3-layout-classic,
+#vm_view tr:nth-child(2) td.fv3-layout-classic {
   padding-left: 20px;
   padding-bottom: 10px;
 }
 
-/* Expand the clickable area of folders and containers
-to the full width of the wrapper */
-#docker_view .hand {
+/* Expand the clickable area of folders and containers (classic only) */
+.fv3-layout-classic .hand {
   position: absolute;
   z-index: 50;
-  display: inline-block;
+  display: flex !important;
+  align-items: center !important;
   left: 0;
   right: 0;
   top: 0;
@@ -62,80 +77,123 @@ to the full width of the wrapper */
   padding: 0;
 }
 
-/* Set a height on the name/text area of
-the folders and containers to the same height of the icon */
-#docker_view .inner {
+/* Set a min-height on the name/text area of
+the folders and containers to the same height of the icon (classic only) */
+.fv3-layout-classic .inner {
   display: inline-block;
-  height: var(--container-logo-size);
+  min-height: var(--container-logo-size);
   margin-left: calc(var(--container-logo-size) + 6px);
 }
 
-/* Compressed folder wrapper and docker container wrapper styles */
-#docker_view .outer {
-  position: relative; /* Needed for absolute positioning of child elements */
-  display: inline-block;
-  background-color: transparent;
+/* Compressed folder wrapper and docker container wrapper styles (classic only) */
+#docker_view .fv3-layout-classic .outer,
+#vm_view .fv3-layout-classic .outer {
+  position: relative;
 }
 
-/* Expanded folder outer wrapper styles */
-#docker_view .folder-showcase-outer[expanded="true"] {
+/* Transparent background and vertical icon centering for all dashboard tiles */
+#docker_view .outer,
+#vm_view .outer {
+  background-color: transparent;
+  display: inline-flex !important;
+  align-items: center !important;
+}
+
+/* Restore block display for expanded folder headers (all layouts) */
+.folder-showcase-outer[expanded="true"] .outer.folder-docker,
+.folder-showcase-outer[expanded="true"] .outer.folder-vm {
+  display: block !important;
+}
+
+
+/*************************************************/
+/* EXPANDED FOLDER WRAPPER STYLES */
+/*************************************************/
+
+/* Allow full folder names on expanded folders (classic only — other layouts use FV3 truncation) */
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .fv3-folder-appname {
+  max-width: none;
+  overflow: visible;
+  white-space: nowrap;
+}
+
+/* Expanded folder outer wrapper styles (classic layout only — other layouts keep FV3 structure) */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"],
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"],
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] {
   float: left;
   display: block;
-  margin-left: -10px; /* Overcome 20px container padding-left by giving
-                      expanded folder a negative left margin */
-  width: calc(100% + 10px); /* Add 10px to the width to overcome negative margin */
+  margin-left: -10px;
+  width: calc(100% + 10px);
   border-radius: 10px;
   border-width: 1px;
   border-style: solid;
   border-color: var(--exfold-drawer-brdr-c);
   background-color: var(--exfold-drawer-bg-c);
 }
-#docker_view .folder-showcase-outer[expanded="true"]:not(:last-child) {
-  margin-bottom: 20px; /* Only apply 20px margin if it's NOT the last element */
+
+.fv3-layout-classic .folder-showcase-outer[expanded="true"]:not(:last-child) {
+  margin-bottom: 20px;
 }
 
 /* Child docker container icons wrapper "drawer" styles */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-showcase {
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-showcase {
   float: left;
   display: block;
   padding: 0 20px;
 }
 
+
+/*************************************************/
+/* TEXT STYLES */
+/*************************************************/
+
 /* Compressed Folder text */
-#docker_view .inner.folder-inner-docker {
+#docker_view .inner.folder-inner-docker,
+#vm_view .inner.folder-inner-vm {
   font-size: var(--folder-name-text-size);
   font-weight: var(--folder-name-text-weight);
 }
-#docker_view .inner.folder-inner-docker .blue-text {
+
+#docker_view .inner.folder-inner-docker .blue-text,
+#vm_view .inner.folder-inner-vm .blue-text {
   color: var(--folder-name-update-text-c); /* Folder with update */
 }
 
 /* Container text */
-#docker_view .inner:not(.folder-inner-docker) {
+#docker_view .inner:not(.folder-inner-docker),
+#vm_view .inner:not(.folder-inner-vm) {
   font-size: var(--container-name-text-size);
   font-weight: var(--container-name-text-weight);
 }
-#docker_view .inner:not(.folder-inner-docker) .blue-text {
+
+#docker_view .inner:not(.folder-inner-docker) .blue-text,
+#vm_view .inner:not(.folder-inner-vm) .blue-text {
   color: var(--container-name-update-text-c); /* Container with update */
 }
 
 /* Hide the "started" and "stopped" text so that only
 the green arrow or red square shows on containers */
-#docker_view .outer:not(.folder-docker) .state {
+#docker_view .outer:not(.folder-docker) .state,
+#vm_view .outer:not(.folder-vm) .state {
   opacity: 0;
 }
+
 
 /*************************************************/
 /* EXPANDED FOLDER HEADER STYLES */
 /*************************************************/
-/* Add padding to the clickable area - builds on compressed styles */
-#docker_view .folder-showcase-outer[expanded="true"] .hand.folder-hand-docker {
+
+/* Add padding to the clickable area - classic layout only */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .hand.folder-hand-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .hand.folder-hand-vm {
   padding: 8px;
 }
 
-/* Expanded folder wrapper/header styles */
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker {
-  display: block;
+/* Expanded folder wrapper/header styles (classic layout only) */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .outer.folder-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .outer.folder-vm {
+  display: block !important;
   float: none;
   padding: 8px;
   border: 1px solid var(--exfold-header-brdr-c);
@@ -145,15 +203,18 @@ the green arrow or red square shows on containers */
 }
 
 /* Folder Icon in Expanded Header */
-#docker_view .folder-showcase-outer[expanded="true"] img.folder-img-docker {
+#docker_view .folder-showcase-outer[expanded="true"] img.folder-img-docker,
+#vm_view .folder-showcase-outer[expanded="true"] img.folder-img-vm {
   /* Default icon size */
   width: var(--exfold-logo-size);
   height: var(--exfold-logo-size);
-  /* Desaturate docker folder icons */
-  filter: saturate(var(--folder-logo-saturation));
+  /* Desaturate docker folder icons (Docker & VM) */
+  filter: saturate(var(--exfold-logo-saturation));
 }
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker:hover img.folder-img-docker {
-  /* Saturate docker folder icons */
+
+#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker:hover img.folder-img-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .outer.folder-vm:hover img.folder-img-vm {
+  /* Saturate docker folder icons (Docker & VM) */
   filter: saturate(var(--exfold-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--exfold-logo-size-hov));
@@ -161,30 +222,41 @@ the green arrow or red square shows on containers */
 
 /* Set a height on the folder-name/text area to the same
 height of the icon - builds on compressed styles */
-#docker_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker {
+#docker_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-vm {
   height: var(--exfold-logo-size);
+}
+
+/* Classic layout: offset text for absolutely-positioned icon */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .inner.folder-inner-vm {
   margin-left: calc(var(--exfold-logo-size) + 7px);
 }
 
 /* Font for the folder name */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker {
+#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .folder-appname-vm {
   font-size: var(--exfold-foldername-text-size);
   font-weight: var(--exfold-foldername-text-weight);
   color: var(--exfold-foldername-text-c);
 }
-#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker.blue-text {
+
+#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker.blue-text,
+#vm_view .folder-showcase-outer[expanded="true"] .folder-appname-vm.blue-text {
   color: var(--exfold-foldername-updatetext-c);
 }
 
 /* Font for the container name inside a folder */
-#docker_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-docker) {
+#docker_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-docker),
+#vm_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-vm) {
   font-size: var(--exfold-contname-text-size);
   font-weight: var(--exfold-contname-text-weight);
   color: var(--exfold-contname-text-c);
 }
 
-/* Down arrow icon */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-docker::after {
+/* Down arrow icon (classic layout only, hidden when collapse toggle is active) */
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-docker::after,
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-vm::after {
   position: absolute;
   content: "\f0d7";
   display: block;
@@ -193,4 +265,6 @@ height of the icon - builds on compressed styles */
   right: 1rem;
   bottom: 0;
 }
-/*************************************************/
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .fv3-expanded-tab::after {
+  content: none;
+}

--- a/urblack-theme/04-table.docker.css
+++ b/urblack-theme/04-table.docker.css
@@ -163,7 +163,7 @@ button.folder-dropdown:active {
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
   height: var(--folderpreview-height);
-  align-items: start;
+  align-items: center;
 }
 
 /* Vertical lines between containers - if enabled */
@@ -192,7 +192,7 @@ button.folder-dropdown:active {
 .folder-preview .folder-preview-wrapper {
   float: none;
   margin-left: var(--container-logo-mrgleft);
-  margin-top: var(--container-logo-mrgtopbottom);
+  margin-top: 4px;
   height: auto;
 }
 /* Container image */

--- a/urblack-theme/04-table.docker.css
+++ b/urblack-theme/04-table.docker.css
@@ -162,7 +162,8 @@ button.folder-dropdown:active {
   border-style: solid !important;
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
-  height: var(--folderpreview-height);
+  height: 100%;
+  min-height: var(--folderpreview-height);
   align-items: center;
 }
 

--- a/urblack-theme/04-table.docker.css
+++ b/urblack-theme/04-table.docker.css
@@ -289,3 +289,25 @@ button.folder-dropdown:active {
   display: block;
   margin-left: 10px;
 }
+
+/*************************************************/
+/* MOBILE / NARROW SCREEN                        */
+/*************************************************/
+@media (max-width: 768px) {
+  .folder-preview .folder-preview-divider {
+    float: none;
+    height: 70%;
+    margin: 0;
+    align-self: center;
+  }
+  .folder-preview.fv3-overflow-scroll .folder-preview-divider:not(:last-child) {
+    height: 36px;
+    margin-top: 10px;
+    align-self: flex-start;
+  }
+  .folder-preview.fv3-overflow-expand .folder-preview-divider:not(:last-child) {
+    height: 42px;
+    margin-top: 12px;
+    align-self: flex-start;
+  }
+}

--- a/urblack-theme/04-table.vm.css
+++ b/urblack-theme/04-table.vm.css
@@ -157,7 +157,7 @@ button.folder-dropdown:active {
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
   height: var(--folderpreview-height);
-  align-items: start;
+  align-items: center;
 }
 
 /* Vertical lines between containers - if enabled */
@@ -186,7 +186,7 @@ button.folder-dropdown:active {
 .folder-preview .folder-preview-wrapper {
   float: none;
   margin-left: var(--container-logo-mrgleft);
-  margin-top: var(--container-logo-mrgtopbottom);
+  margin-top: 4px;
   height: auto;
 }
 /* Container image */

--- a/urblack-theme/04-table.vm.css
+++ b/urblack-theme/04-table.vm.css
@@ -156,7 +156,8 @@ button.folder-dropdown:active {
   border-style: solid !important;
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
-  height: var(--folderpreview-height);
+  height: 100%;
+  min-height: var(--folderpreview-height);
   align-items: center;
 }
 

--- a/urblack-theme/04-table.vm.css
+++ b/urblack-theme/04-table.vm.css
@@ -282,3 +282,25 @@ button.folder-dropdown:active {
   display: block;
   margin-left: 10px;
 }
+
+/*************************************************/
+/* MOBILE / NARROW SCREEN                        */
+/*************************************************/
+@media (max-width: 768px) {
+  .folder-preview .folder-preview-divider {
+    float: none;
+    height: 70%;
+    margin: 0;
+    align-self: center;
+  }
+  .folder-preview.fv3-overflow-scroll .folder-preview-divider:not(:last-child) {
+    height: 36px;
+    margin-top: 10px;
+    align-self: flex-start;
+  }
+  .folder-preview.fv3-overflow-expand .folder-preview-divider:not(:last-child) {
+    height: 42px;
+    margin-top: 12px;
+    align-self: flex-start;
+  }
+}

--- a/urblack-theme/04-table.vm.css
+++ b/urblack-theme/04-table.vm.css
@@ -1,66 +1,63 @@
 /*************************************************/
 /* BASICS */
 /*************************************************/
-/* Apply border-box to all elements inside the docker table */
-#docker_containers,
-#docker_containers * {
+/* Apply border-box to all elements inside the vm table */
+#kvm_table,
+#kvm_table * {
   box-sizing: border-box;
 }
 
-/* Table row colors */
-#docker_containers.tablesorter {
-  background-color: var(--row-base-bg-c);
-}
-#docker_containers.tablesorter tbody tr:nth-child(even) {
-  background-color: var(--row-even-bg-c);
+#kvm_table .folder-name,
+#kvm_table .folder-outer {
+  width: auto;
 }
 
 /* Style all links that are not container tools */
-#docker_containers :not(.folder-element-custom-btn) > a,
-#docker_containers :not(.folder-element-custom-btn) > a:link,
-#docker_containers :not(.folder-element-custom-btn) > a:visited {
+#kvm_table :not(.folder-element-custom-btn) > a,
+#kvm_table :not(.folder-element-custom-btn) > a:link,
+#kvm_table :not(.folder-element-custom-btn) > a:visited {
   color: var(--cscheme-link);
   text-decoration: none;
 }
-#docker_containers :not(.folder-element-custom-btn) > a:hover {
+#kvm_table :not(.folder-element-custom-btn) > a:hover {
   color: var(--cscheme-linkhov);
   text-decoration: none;
 }
 
 /* Style all container names with updates available */
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text,
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:link,
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:visited {
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text,
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:link,
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:visited {
   color: var(--container-name-update-text-c);
   text-decoration: none;
   font-weight: bold;
 }
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:hover {
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:hover {
   color: var(--container-name-update-texthov-c);
   text-decoration: none;
   font-weight: bold;
 }
 
 /* Warning and Passed Text */
-#docker_containers .orange-text,
-#docker_containers .warning {
+#kvm_table .orange-text,
+#kvm_table .warning {
   color: var(--warn-orange-text-c);
 }
-#docker_containers .green,
-#docker_containers .green-text,
-#docker_containers .passed {
+#kvm_table .green,
+#kvm_table .green-text,
+#kvm_table .passed {
   color: var(--pass-green-text-c);
 }
-#docker_containers .blue-text {
+#kvm_table .blue-text {
   color: var(--accent-blue-text-c);
 }
 
 /* Autostart switches *//*
-#docker_containers .switch-button-background.checked,
+#kvm_table .switch-button-background.checked,
 .preview-status .switch-button-background.checked {
   background-color: var(--cscheme-interface-passed);
 }
-#docker_containers .switch-button-label.on,
+#kvm_table .switch-button-label.on,
 .preview-status .switch-button-label.on {
   color: var(--cscheme-interface-passed);
 }
@@ -75,8 +72,6 @@
 /* Prevent folder icon from being clipped when scaled on hover */
 td.folder-name .folder-outer {
   overflow: visible;
-  white-space: nowrap;
-  width: auto;
 }
 /* Wrapper around folder icon, name, and toggle */
 .folder .folder-name-sub {
@@ -119,7 +114,6 @@ td.folder-name .folder-outer {
 /* Folder toggle open button */
 button.folder-dropdown {
   float: none;
-  margin-left: auto;
   color: var(--folder-button-text-c);
   border: none;
   background: var(--folder-button-background);
@@ -200,14 +194,14 @@ button.folder-dropdown:active {
   width: var(--container-logo-size);
   height: var(--container-logo-size);
   margin-right: 5px;
-  /* Desaturate docker container icons - Or as specified in vars */
+  /* Desaturate vm container icons - Or as specified in vars */
   filter: saturate(var(--container-logo-saturation));
   /* Add a transition for smooth scaling */
   transition: transform 0.3s ease;
 }
 /* Container image hover */
 .folder-preview-wrapper:hover .outer img.img {
-  /* Saturate docker container icons - Or as specified in vars */
+  /* Saturate vm container icons - Or as specified in vars */
   filter: saturate(var(--container-logo-saturation-hov));
   /* Scale the image on hover */
   transform: scale(var(--container-logo-size-hov));
@@ -261,30 +255,29 @@ button.folder-dropdown:active {
 
 /****** Give more space for containers *******/
 /* Autostart column */
-#docker_containers th.nine {
+#kvm_table th.nine {
   width: 0px; /*110px;*/
   padding: 0;
 }
-
 
 /*************************************************/
 /* EXPANDED FOLDER AND NO FOLDER CONTAINER ROW */
 /*************************************************/
 /* Cell for container name */
-#docker_containers .folder-element .ct-name,
-#docker_containers .ct-name:not(.folder-name) {
+#kvm_table .folder-element .ct-name,
+#kvm_table .ct-name:not(.folder-name) {
   width: auto !important;
   padding: 8px 20px 8px var(--container-nofold-namebox-padding-left) !important;
 }
 
 /* Container name text */
-#docker_containers .inner:not(.folder-inner) .appname {
+#kvm_table .inner:not(.folder-inner) .appname {
   font-size: var(--container-name-text-size);
   font-weight: var(--container-name-text-weight);
 }
 
 /* Wait form on autostart containers */
-#docker_containers tr.sortable:not(.folder) td:nth-child(7) span:last-of-type {
+#kvm_table tr.sortable:not(.folder) td:nth-child(7) span:last-of-type {
   float: none !important;
   display: block;
   margin-left: 10px;

--- a/urblack-theme/06-icons.dashboard.css
+++ b/urblack-theme/06-icons.dashboard.css
@@ -1,72 +1,114 @@
 /*************************************************/
 /* STARTED/STOPPED ICON SIZES */
 /*************************************************/
+
 /* Folder Status */
-#docker_view .outer.folder-docker i::before {
+#docker_view .outer.folder-docker i::before,
+#vm_view .outer.folder-vm i::before {
   font-size: var(--folder-status-size);
 }
+
 /* Expanded Folder Status */
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker i::before {
+#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker i::before,
+#vm_view .folder-showcase-outer[expanded="true"] .outer.folder-vm i::before {
   font-size: var(--exfold-status-size);
 }
+
 /* Container Status */
-#docker_view .outer.folder-element-docker i::before {
+#docker_view .outer.folder-element-docker i::before,
+#vm_view .outer.folder-element-vm i::before {
   font-size: var(--container-status-size);
 }
+
 /* Container Autostart Status */
-#docker_view .outer.folder-element-docker.autostart i::before {
+#docker_view .outer.folder-element-docker.autostart i::before,
+#vm_view .outer.folder-element-vm.autostart i::before {
   font-size: var(--container-atostart-status-size);
 }
+
 
 /*************************************************/
 /* DEFAULT STARTED/STOPPED ICONS */
 /*************************************************/
+
 /* Started Icon */
-#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before {
+#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before,
+#vm_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before {
   content: var(--container-started-icon);
   color: var(--container-started-icon-c);
 }
+
 /* Stopped Icon */
-#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before {
+#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before,
+#vm_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before {
   content: var(--container-stopped-icon);
   color: var(--container-stopped-icon-c);
 }
+
 /* Spin Icon - Started */
-#docker_view .outer i.started.fa-spin::before {
+#docker_view .outer i.started.fa-spin::before,
+#vm_view .outer i.started.fa-spin::before {
   content: var(--container-spin-started-icon);
   color: var(--container-spin-started-icon-c);
 }
+
 /* Spin Icon - Stopped */
-#docker_view .outer i.stopped.fa-spin::before {
+#docker_view .outer i.stopped.fa-spin::before,
+#vm_view .outer i.stopped.fa-spin::before {
   content: var(--container-spin-stopped-icon);
   color: var(--container-spin-stopped-icon-c);
 }
 
+
 /*************************************************/
 /* AUTOSTART ICONS */
 /*************************************************/
+
 /* Container Icons */
-#docker_view .outer:not(.folder-docker).autostart.started i:not(.fa-spin)::before {
+#docker_view .outer:not(.folder-docker).autostart.started i:not(.fa-spin)::before,
+#vm_view .outer:not(.folder-vm).autostart.started i:not(.fa-spin)::before {
   content: var(--container-autostart-started-icon); /* Replace the green triangle with a different icon */
   color: var(--container-autostart-started-icon-c);
 }
-#docker_view .outer:not(.folder-docker).autostart.stopped i:not(.fa-spin)::before {
+
+#docker_view .outer:not(.folder-docker).autostart.stopped i:not(.fa-spin)::before,
+#vm_view .outer:not(.folder-vm).autostart.stopped i:not(.fa-spin)::before {
   content: var(--container-autostart-stopped-icon); /* Replace the red square with a different icon */
   color: var(--container-autostart-stopped-icon-c);
 }
 
+/* Spin Icon - Started */
+#docker_view .outer:not(.folder-docker).autostart.started i.fa-spin::before,
+#vm_view .outer:not(.folder-vm).autostart.started i.fa-spin::before {
+  content: var(--container-spin-started-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-started-icon-c);
+}
+
+/* Spin Icon - Stopped */
+#docker_view .outer:not(.folder-docker).autostart.stopped i.fa-spin::before,
+#vm_view .outer:not(.folder-vm).autostart.stopped i.fa-spin::before {
+  content: var(--container-spin-stopped-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-stopped-icon-c); /* Set spin color of stopped autostart container */
+}
+
+
 /* Folder Icons */
 /* Replace the default container status icon with an icon
 denoting presence of autostart containers */
-#docker_view .outer.folder-docker.autostart-full i::before {
+#docker_view .outer.folder-docker.autostart-full i::before,
+#vm_view .outer.folder-vm.autostart-full i::before {
   content: var(--folder-autostart-full-icon);
   color: var(--folder-autostart-full-icon-c); /* Green color when all autostart containers are started */
 }
-#docker_view .outer.folder-docker.autostart-partial i::before {
+
+#docker_view .outer.folder-docker.autostart-partial i::before,
+#vm_view .outer.folder-vm.autostart-partial i::before {
   content: var(--folder-autostart-partial-icon);
   color: var(--folder-autostart-partial-icon-c); /* Orange when some autostart containers are started */
 }
-#docker_view .outer.folder-docker.autostart-off i::before {
+
+#docker_view .outer.folder-docker.autostart-off i::before,
+#vm_view .outer.folder-vm.autostart-off i::before {
   content: var(--folder-autostart-off-icon);
   color: var(--folder-autostart-off-icon-c); /* Red when no autostart containers are started */
 }

--- a/urblack-theme/06-icons.docker-vm.css
+++ b/urblack-theme/06-icons.docker-vm.css
@@ -125,6 +125,18 @@
   content: var(--container-autostart-stopped-icon); /* Replace the red square with a different icon */
   color: var(--container-autostart-stopped-icon-c);
 }
+
+/* Container autostart Spin Icon - Started */
+.outer:not(.folder-outer).autostart i.started.fa-spin::before {
+  content: var(--container-spin-started-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-started-icon-c);
+}
+/* Container autostart Spin Icon - Stopped */
+.outer:not(.folder-outer).autostart i.stopped.fa-spin::before {
+  content: var(--container-spin-stopped-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-stopped-icon-c);
+}
+
 /* Folder Icons */
 /* Replace the folder's default ontainer status icon with an icon
 denoting presence of autostart containers */

--- a/urblack-theme/08-fv3-overrides.dashboard-docker-vm.css
+++ b/urblack-theme/08-fv3-overrides.dashboard-docker-vm.css
@@ -1,0 +1,113 @@
+/*************************************************/
+/* FV3 PLUGIN VARIABLE OVERRIDES */
+/* Override FolderView3 built-in CSS variables    */
+/* to match this theme's color palette            */
+/*************************************************/
+:root {
+  /* Graph colors */
+  --folder-view3-graph-cpu: var(--cscheme-cpu);
+  --folder-view3-graph-mem: var(--cscheme-mem);
+
+  /* Tooltip / Advanced Preview theme colors */
+  --fv3-surface-tint: rgba(255, 255, 255, 0.05);
+  --fv3-hover-bg: rgba(255, 255, 255, 0.1);
+  --fv3-border: 1px solid rgba(255, 255, 255, 0.15);
+
+  /* Dashboard: Inset layout */
+  --fv3-inset-border-color: var(--cscheme-foreline1-dark);
+  --fv3-inset-fill: var(--cscheme-foreline4);
+  --fv3-inset-showcase-border: var(--cscheme-foreline4);
+  --fv3-inset-showcase-fill: rgba(33, 33, 33, 0.4);
+  --fv3-inset-bg: transparent;
+  --fv3-showcase-bg: transparent;
+
+  /* Dashboard: Embossed layout */
+  --fv3-embossed-border: var(--cscheme-foreline1-dark);
+  --fv3-embossed-accent: var(--cscheme-accent1);
+  --fv3-embossed-bg: transparent;
+  --fv3-embossed-shadow: none;
+  --fv3-embossed-inner-border: var(--cscheme-foreline4);
+  --fv3-embossed-inner-bg: rgba(255, 255, 255, 0.03);
+}
+
+/*************************************************/
+/* COLLAPSE TOGGLE BUTTON — styled as the down arrow */
+/*************************************************/
+button.fv3-collapse-toggle {
+  z-index: 51;
+  position: absolute;
+  right: 1rem;
+  bottom: 0;
+  top: auto;
+  left: auto;
+  transform: none;
+  width: auto;
+  height: auto;
+  max-width: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: inherit;
+  font-size: 3rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+button.fv3-collapse-toggle:hover {
+  background: transparent;
+  border: none;
+  color: var(--cscheme-accent1);
+  transform: none;
+}
+button.fv3-collapse-toggle:active {
+  transform: none;
+}
+/* Accordion/Embossed: static positioning next to folder name */
+.fv3-layout-accordion button.fv3-collapse-toggle,
+.fv3-layout-embossed button.fv3-collapse-toggle {
+  position: static;
+  font-size: 1.2rem;
+  margin-left: 10px;
+  vertical-align: middle;
+}
+/* Force chevron-up icon, overriding icon theme rules */
+#docker_view .outer.folder-docker button.fv3-collapse-toggle i::before,
+#docker_view .outer.folder-element-docker button.fv3-collapse-toggle i::before,
+#vm_view .outer.folder-vm button.fv3-collapse-toggle i::before,
+#vm_view .outer.folder-element-vm button.fv3-collapse-toggle i::before {
+  content: "\f077";
+  font-family: FontAwesome;
+  color: inherit;
+  font-size: inherit;
+}
+
+/*************************************************/
+/* ACCORDION / FULLWIDTH / INSET / EMBOSSED      */
+/* Extra padding for larger custom theme icons    */
+/*************************************************/
+.fv3-layout-accordion .folder-showcase:not(:empty) {
+  border-color: var(--cscheme-foreline4);
+  border-left-color: var(--cscheme-accent1);
+  padding: 12px;
+  overflow: visible;
+}
+
+
+.fv3-fullwidth-panel {
+  border-color: var(--cscheme-foreline4);
+  border-left-color: var(--cscheme-accent1);
+  padding: 12px;
+}
+
+
+.fv3-layout-inset .folder-showcase:not(:empty) {
+  padding: 12px;
+  overflow: visible;
+}
+
+.fv3-layout-embossed .folder-showcase:not(:empty) {
+  padding: 12px;
+  overflow: visible;
+}

--- a/urblack-theme/README.md
+++ b/urblack-theme/README.md
@@ -1,6 +1,6 @@
 # unRAID Black Theme
 
-_Use of this theme requires FolderView version **2023.10.04**_
+_Use of this theme requires FolderView3 version **2026.03.23.3** or later_
 
 Based on color and style from the out-of-box **Black** theme in **unRAID**.
 Dashboard and Docker table have been fully themed with easy-to-access variables that even those with limited CSS skills can edit and tweak.
@@ -9,21 +9,23 @@ Dashboard and Docker table have been fully themed with easy-to-access variables 
 
 File naming determines load order. _Do not change the naming of these files unless you know what you're doing._
 
-- **01-colors.dashboard-docker.css:** _Color scheme file. Stores all colors used by other dashboard and docker page CSS files._
+- **01-colors.dashboard-docker-vm.css:** _Color scheme file. Stores all colors used by dashboard, docker, and VM page CSS files._
 - **02-vars.dashboard.css:** _Variables used by other dashboard CSS files. Most editing can be done in this file._
-- **02-vars.docker.css:** _Variables used by other docker page CSS files. Most editing can be done in this file._
+- **02-vars.docker-vm.css:** _Variables used by other docker and VM page CSS files. Most editing can be done in this file._
 - **03-vars-icons.dashboard.css:** _Variables pertaining specifically to icons on the dashboard._
-- **03-vars-icons.docker.css:** _Variables pertaining specifically to icons on the docker page._
+- **03-vars-icons.docker-vm.css:** _Variables pertaining specifically to icons on the docker and VM pages._
 - **04-dash.dashboard.css:** _Main CSS selectors file for the dashboard._
 - **04-table.docker.css:** _Main CSS selectors file for the docker page._
+- **04-table.vm.css:** _Main CSS selectors file for the VM page._
 - **05-tableadv.docker.css:** _Selectors and rules pertaining to elements added with the Advanced View switch._
 - **06-icons.dashboard.css:** _Selectors and rules specific to icons on the dashboard._
-- **06-icons.docker.css:** _Selectors and rules specific to icons on the docker page._
+- **06-icons.docker-vm.css:** _Selectors and rules specific to icons on the docker and VM pages._
 - **07-advcontext.docker.css:** _Variables, selectors, and rules specific to the Advanced Context Menu._
+- **08-fv3-overrides.dashboard-docker-vm.css:** _FolderView3 plugin variable overrides and layout adjustments for accordion, fullwidth, inset, and embossed modes._
 
 ## Sample Images
 
-_Icons in these images are desaturated by the CSS rules and saturate on hover. These settings are easily disabled by changing the variable values in the **02-vars.dashboard.css** and **02-vars.docker.css** files._
+_Icons in these images are desaturated by the CSS rules and saturate on hover. These settings are easily disabled by changing the variable values in the **02-vars.dashboard.css** and **02-vars.docker-vm.css** files._
 
 ### Example:
 

--- a/urgray-theme/01-colors.dashboard-docker-vm.css
+++ b/urgray-theme/01-colors.dashboard-docker-vm.css
@@ -1,5 +1,5 @@
 /*************************************************/
-/* COLOR SCHEME - BASED ON UNRAID STOCK BLACK THEME
+/* COLOR SCHEME - BASED ON UNRAID STOCK GRAY THEME
 Change these settings to your preference */
 /*************************************************/
 /* Look up a hex color convertor online
@@ -7,22 +7,35 @@ like https://htmlcolorcodes.com/color-picker/ */
 /*************************************************/
 :root {
   --cscheme-accent1: #ff8c2f;
-  --cscheme-accent2: #3e6dba;
+  --cscheme-accent1-dark: #e07020;
+  --cscheme-accent2: #0072c6;
   --cscheme-accent3: #4f8a10;
+  --cscheme-accent4: #256f92;
+  --cscheme-accent5: #00BCD4;
+  --cscheme-accent6: #9575CD;
 
-  --cscheme-foreline1: #f2f2f2;
-  --cscheme-foreline2: #a1a1a1;
-  --cscheme-foreline3: #787878;
-  --cscheme-foreline4: #444444;
-  --cscheme-backfill1: #262626;
-  --cscheme-backfill2: #212121;
-  --cscheme-backfill3: #1c1b1b;
-  --cscheme-backfill4: #191818;
+  --cscheme-foreline0: #d0d0d0;
+  --cscheme-foreline1: #b0b0b0;
+  --cscheme-foreline1-light: #c0c0c0;
+  --cscheme-foreline1-dark: #808080;
+  --cscheme-foreline2: #9b9b9b;
+  --cscheme-foreline3: #606e7f;
+  --cscheme-foreline4: #606060;
+  --cscheme-backfill1: #323432;
+  --cscheme-backfill2: #1b1d1b;
+  --cscheme-backfill3: #141613;
+  --cscheme-backfill4: #121510;
+  --cscheme-cpu: #00BCD4; /* CPU accent color Graph Line */
+  --cscheme-mem: #673AB7; /* Mem accent color Graph Line */
 
   --cscheme-interface-alert: #f0000c;
+  --cscheme-interface-alert2: #fb039a;
   --cscheme-interface-warn: #ff8c2f;
+  --cscheme-interface-warn2: #FFEB3B;
   --cscheme-interface-attention: #d6ff20;
+  --cscheme-interface-attention2: #FFEB3B;
   --cscheme-interface-passed: #4caf50;
+  --cscheme-interface-passed2: #4caf50;
   --cscheme-interface-accent: #2cabe3;
 
   --cscheme-link: #486dba; /* Text links within the docker table */
@@ -31,6 +44,6 @@ like https://htmlcolorcodes.com/color-picker/ */
   --cscheme-tool-linkhov: #2cabe3; /* Container tools - hover */
   --cscheme-cont-update: #ff8c2f; /* Container with update */
   --cscheme-cont-updatehov: #ffc04c; /* Container with update - hover (only in docker table) */
-  --cscheme-folder-update: #3e6dba; /* Folder on dashboard with update within */
+  --cscheme-folder-update: #0072c6; /* Folder on dashboard with update within */
   --cscheme-exfolder-update: #ff8c2f; /* Expanded folder on dashboard with update within */
 }

--- a/urgray-theme/02-vars.dashboard.css
+++ b/urgray-theme/02-vars.dashboard.css
@@ -10,9 +10,9 @@
 
   /* Folder icon */
   --folder-logo-size: 32px;
-  --folder-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --folder-logo-saturation: 0; /* Initial color depth for folder icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --folder-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --folder-logo-size-hov: 1.2;
+  --folder-logo-saturation: 0;
+  --folder-logo-saturation-hov: 1;
 
   /* Default container name text size and weight */
   --container-name-text-size: 1.3rem;
@@ -22,9 +22,12 @@
 
   /* Container icon */
   --container-logo-size: 32px;
-  --container-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --container-logo-saturation: 0; /* Initial color depth for container icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --container-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --container-logo-size-hov: 1.2;
+  --container-logo-saturation: 0;
+  --container-logo-saturation-hov: 1;
+
+  /* Override FV3 inset fill to match classic expanded header grey */
+  --fv3-inset-fill: var(--cscheme-foreline4);
 
   /****** EXPANDED FOLDER STYLES ******/
   --exfold-header-brdr-c: var(--cscheme-backfill1); /* Border color for the header */
@@ -38,9 +41,9 @@
 
   /* Folder icon in expanded folder header */
   --exfold-logo-size: 48px;
-  --exfold-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --exfold-logo-saturation: 0; /* Initial color depth for folder icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --exfold-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --exfold-logo-size-hov: 1.2;
+  --exfold-logo-saturation: 0;
+  --exfold-logo-saturation-hov: 1;
 
   /* Container within an expanded folder */
   --exfold-contname-text-c: inherit; /* Color for the container name when inside a folder */

--- a/urgray-theme/02-vars.docker-vm.css
+++ b/urgray-theme/02-vars.docker-vm.css
@@ -4,15 +4,21 @@
 :root {
   /* Passed/Warning/Green/Orange Text */
   --warn-orange-text-c: var(--cscheme-interface-warn);
-  --pass-green-text-c: var(--cscheme-interface-good);
+  --pass-green-text-c: var(--cscheme-interface-passed);
   --accent-blue-text-c: var(--cscheme-interface-accent);
 
   /* Table Rows */
   --row-base-bg-c: var(--cscheme-backfill4);
   --row-even-bg-c: var(--cscheme-backfill2);
 
+  /* Table Rows VMs Colors */
+  --fv3-row-bg: var(--row-base-bg-c);
+  --fv3-row-alt-bg: var(--row-even-bg-c);
+
   /* Folder Name/Logo Area */
-  --folderbox-width: 250px; /* May need to be increased if --folder-name-text-size is too big */
+  --fv3-folder-name-min-width: 250px;
+  --fv3-folder-name-max-width: none;
+  --folderbox-width: var(--fv3-folder-name-min-width); /* May need to be increased if --folder-name-text-size is too big */
   --folderbox-height: calc(var(--folder-logo-size) + (var(--folderbox-padding-topbottom) * 2) + (var(--folderbox-brdr-width-topbottom) * 2));
   --folderbox-padding-topbottom: 10px;
   --folderbox-padding-leftright: 10px;
@@ -22,14 +28,22 @@
   --folderbox-brdr-width-right: 3px;
 
   --folder-logo-size: 40px;
-  --folder-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --folder-logo-saturation: 0; /* Initial color depth for folder icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --folder-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --folder-logo-size-hov: 1.2;
+  --folder-logo-saturation: 0;
+  --folder-logo-saturation-hov: 1;
   --folder-logo-mrgright: 8px;
   --folder-name-text-size: 1.5rem;
   --folder-name-text-weight: bold;
-  --folder-startstop-text-size: 1.2rem; /* 0 to hide */
-  --folder-startstop-text-mrgleft: 7px; /* 0 to hide */
+  --folder-startstop-text-size: 1.2rem;
+  --folder-startstop-text-mrgleft: 7px;
+
+  --folder-button-size-hov: 1.08;
+  --folder-button-size-act: 0.98;
+  --folder-button-background: linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1)) 0 0 no-repeat, linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1)) 0 100% no-repeat, linear-gradient(0deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1-dark)) 0 100% no-repeat, linear-gradient(0deg, var(--cscheme-foreline1) 0, var(--cscheme-foreline1)) 100% 100% no-repeat;
+  --folder-button-background-size: 100% 2px, 100% 2px, 2px 100%, 2px 100%;
+  --folder-button-background-hov: linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1));
+  --folder-button-text-c: var(--cscheme-foreline1);
+  --folder-button-text-c-hov: var(--cscheme-foreline0);
 
   /* Folder/Container Preview Row */
   --folderpreview-height: calc(var(--container-logo-size) + (var(--container-logo-mrgtopbottom) * 2) + (var(--folderpreview-brdr-width-topbottom) * 2));
@@ -40,17 +54,17 @@
 
   /* Container */
   --container-logo-size: 38px;
-  --container-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --container-logo-saturation: 0; /* Initial color depth for container icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --container-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --container-logo-size-hov: 1.2;
+  --container-logo-saturation: 0;
+  --container-logo-saturation-hov: 1;
   --container-logo-mrgtopbottom: 10px;
   --container-logo-mrgleft: 10px;
   --container-name-text-size: 1.3rem;
   --container-name-text-weight: bold;
   --container-name-update-text-c: var(--cscheme-cont-update);
   --container-name-update-texthov-c: var(--cscheme-cont-updatehov);
-  --container-startstop-text-size: 0; /* default 1.1rem */
-  --container-startstop-text-mrgleft: 0; /* default 7px */
+  --container-startstop-text-size: 0;
+  --container-startstop-text-mrgleft: 0;
   --container-nofold-namebox-padding-left: calc(6px + var(--folderbox-padding-leftright) + var(--folderbox-brdr-width-left));
 }
 /*************************************************/

--- a/urgray-theme/03-vars-icons.dashboard.css
+++ b/urgray-theme/03-vars-icons.dashboard.css
@@ -29,17 +29,17 @@ like https://htmlcolorcodes.com/color-picker/ */
   --container-spin-stopped-icon: "\f110"; /* Spin icon temporarily shown when a container is changing from stopped to started */
 
   /* STARTED/STOPPED ICON COLORS */
-  --folder-started-icon-c: var(--cscheme-interface-good); /* Normal started icon - default is green */
+  --folder-started-icon-c: var(--cscheme-interface-passed); /* Normal started icon - default is green */
   --folder-stopped-icon-c: var(--cscheme-interface-alert); /* Normal stopped icon - default is red */
-  --folder-autostart-full-icon-c: var(--cscheme-interface-good); /* Indicate ALL autostart containers within the folder are started */
+  --folder-autostart-full-icon-c: var(--cscheme-interface-passed); /* Indicate ALL autostart containers within the folder are started */
   --folder-autostart-partial-icon-c: var(--cscheme-interface-warn); /* Indicates SOME autostart containers within the folder are started */
   --folder-autostart-off-icon-c: var(--cscheme-interface-alert); /* Indicates NO autostart containers within the folder are started */
 
   --container-spin-started-icon-c: var(--cscheme-interface-warn); /* Spin icon temporarily shown when a container is changing from started to stopped */
   --container-spin-stopped-icon-c: var(--cscheme-interface-attention); /* Spin icon temporarily shown when a container is changing from stopped to started */
-  --container-started-icon-c: var(--cscheme-interface-good); /* Normal started icon - default is play triangle */
+  --container-started-icon-c: var(--cscheme-interface-passed); /* Normal started icon - default is play triangle */
   --container-stopped-icon-c: var(--cscheme-interface-alert); /* Normal stopped icon - default is rounded square */
-  --container-autostart-started-icon-c: var(--cscheme-interface-good); /* Indicates autostart container is started */
+  --container-autostart-started-icon-c: var(--cscheme-interface-passed); /* Indicates autostart container is started */
   --container-autostart-stopped-icon-c: var(--cscheme-interface-alert); /* Indicates autostart container is stopped */
 
   /* STARTED/STOPPED ICON SIZES */

--- a/urgray-theme/03-vars-icons.docker-vm.css
+++ b/urgray-theme/03-vars-icons.docker-vm.css
@@ -1,5 +1,5 @@
 /*************************************************/
-/* VARIABLES FOR ICONS IN DOCKER TABLE - 
+/* VARIABLES FOR ICONS IN DOCKER TABLE -
 Change these settings to your preference */
 /*************************************************/
 /* See https://fontawesome.com/icons for icons.

--- a/urgray-theme/04-dash.dashboard.css
+++ b/urgray-theme/04-dash.dashboard.css
@@ -1,39 +1,54 @@
 /*************************************************/
 /* FOLDER & CONTAINER LOGO ICON HOVER EFFECTS */
 /*************************************************/
+
 /* ALL Folder and Container Icons (also affects expanded header icon) */
-#docker_view .outer img {
+#docker_view .outer img,
+#vm_view .outer img {
   /* Add a transition for smooth scaling */
   transition: transform 0.3s ease;
 }
+
 /* ************ Folder Icon (Compressed Only) ************ */
-#docker_view .outer.folder-docker img {
+#docker_view .outer.folder-docker img,
+#vm_view .outer.folder-vm img {
   /* Default icon size */
   height: var(--folder-logo-size);
   width: var(--folder-logo-size);
-  /* Desaturate docker folder icons */
+  /* Desaturate docker folder icons (Docker & VM) */
   filter: saturate(var(--folder-logo-saturation));
 }
-#docker_view .outer.folder-docker:hover img {
-  /* Saturate docker folder icons */
+
+#docker_view .outer.folder-docker:hover img,
+#vm_view .outer.folder-vm:hover img {
+  /* Saturate docker folder icons (Docker & VM) */
   filter: saturate(var(--folder-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--folder-logo-size-hov));
 }
+
 /* ************ Container Icon ************ */
-#docker_view .outer.folder-element-docker img {
+#docker_view .outer.folder-element-docker img,
+#vm_view .outer.folder-element-vm img {
   /* Default icon size */
   height: var(--container-logo-size);
   width: var(--container-logo-size);
-  /* Desaturate docker container icons */
+  /* Desaturate docker container icons (Docker & VM) */
   filter: saturate(var(--container-logo-saturation));
 }
-#docker_view .outer.folder-element-docker:hover img {
-  /* Saturate docker container icons */
+
+#docker_view .outer.folder-element-docker:hover img,
+#vm_view .outer.folder-element-vm:hover img {
+  /* Saturate docker container icons (Docker & VM) */
   filter: saturate(var(--container-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--container-logo-size-hov));
 }
+
+
+/*************************************************/
+/* SHARED LAYOUT RULES */
+/*************************************************/
 
 /* Apply border-box to all elements inside the docker and vm panes */
 #docker_view *,
@@ -42,19 +57,19 @@
 }
 
 /* Add a padding left to the entire docker and vm icon area
-- this compensates for the expanded folder header */
-#docker_view tr:nth-child(2) td,
-#vm_view tr:nth-child(2) td {
+- this compensates for the expanded folder header (classic only) */
+#docker_view tr:nth-child(2) td.fv3-layout-classic,
+#vm_view tr:nth-child(2) td.fv3-layout-classic {
   padding-left: 20px;
   padding-bottom: 10px;
 }
 
-/* Expand the clickable area of folders and containers
-to the full width of the wrapper */
-#docker_view .hand {
+/* Expand the clickable area of folders and containers (classic only) */
+.fv3-layout-classic .hand {
   position: absolute;
   z-index: 50;
-  display: inline-block;
+  display: flex !important;
+  align-items: center !important;
   left: 0;
   right: 0;
   top: 0;
@@ -62,80 +77,123 @@ to the full width of the wrapper */
   padding: 0;
 }
 
-/* Set a height on the name/text area of
-the folders and containers to the same height of the icon */
-#docker_view .inner {
+/* Set a min-height on the name/text area of
+the folders and containers to the same height of the icon (classic only) */
+.fv3-layout-classic .inner {
   display: inline-block;
-  height: var(--container-logo-size);
+  min-height: var(--container-logo-size);
   margin-left: calc(var(--container-logo-size) + 6px);
 }
 
-/* Compressed folder wrapper and docker container wrapper styles */
-#docker_view .outer {
-  position: relative; /* Needed for absolute positioning of child elements */
-  display: inline-block;
-  background-color: transparent;
+/* Compressed folder wrapper and docker container wrapper styles (classic only) */
+#docker_view .fv3-layout-classic .outer,
+#vm_view .fv3-layout-classic .outer {
+  position: relative;
 }
 
-/* Expanded folder outer wrapper styles */
-#docker_view .folder-showcase-outer[expanded="true"] {
+/* Transparent background and vertical icon centering for all dashboard tiles */
+#docker_view .outer,
+#vm_view .outer {
+  background-color: transparent;
+  display: inline-flex !important;
+  align-items: center !important;
+}
+
+/* Restore block display for expanded folder headers (all layouts) */
+.folder-showcase-outer[expanded="true"] .outer.folder-docker,
+.folder-showcase-outer[expanded="true"] .outer.folder-vm {
+  display: block !important;
+}
+
+
+/*************************************************/
+/* EXPANDED FOLDER WRAPPER STYLES */
+/*************************************************/
+
+/* Allow full folder names on expanded folders (classic only — other layouts use FV3 truncation) */
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .fv3-folder-appname {
+  max-width: none;
+  overflow: visible;
+  white-space: nowrap;
+}
+
+/* Expanded folder outer wrapper styles (classic layout only — other layouts keep FV3 structure) */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"],
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"],
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] {
   float: left;
   display: block;
-  margin-left: -10px; /* Overcome 20px container padding-left by giving
-                      expanded folder a negative left margin */
-  width: calc(100% + 10px); /* Add 10px to the width to overcome negative margin */
+  margin-left: -10px;
+  width: calc(100% + 10px);
   border-radius: 10px;
   border-width: 1px;
   border-style: solid;
   border-color: var(--exfold-drawer-brdr-c);
   background-color: var(--exfold-drawer-bg-c);
 }
-#docker_view .folder-showcase-outer[expanded="true"]:not(:last-child) {
-  margin-bottom: 20px; /* Only apply 20px margin if it's NOT the last element */
+
+.fv3-layout-classic .folder-showcase-outer[expanded="true"]:not(:last-child) {
+  margin-bottom: 20px;
 }
 
 /* Child docker container icons wrapper "drawer" styles */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-showcase {
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-showcase {
   float: left;
   display: block;
   padding: 0 20px;
 }
 
+
+/*************************************************/
+/* TEXT STYLES */
+/*************************************************/
+
 /* Compressed Folder text */
-#docker_view .inner.folder-inner-docker {
+#docker_view .inner.folder-inner-docker,
+#vm_view .inner.folder-inner-vm {
   font-size: var(--folder-name-text-size);
   font-weight: var(--folder-name-text-weight);
 }
-#docker_view .inner.folder-inner-docker .blue-text {
+
+#docker_view .inner.folder-inner-docker .blue-text,
+#vm_view .inner.folder-inner-vm .blue-text {
   color: var(--folder-name-update-text-c); /* Folder with update */
 }
 
 /* Container text */
-#docker_view .inner:not(.folder-inner-docker) {
+#docker_view .inner:not(.folder-inner-docker),
+#vm_view .inner:not(.folder-inner-vm) {
   font-size: var(--container-name-text-size);
   font-weight: var(--container-name-text-weight);
 }
-#docker_view .inner:not(.folder-inner-docker) .blue-text {
+
+#docker_view .inner:not(.folder-inner-docker) .blue-text,
+#vm_view .inner:not(.folder-inner-vm) .blue-text {
   color: var(--container-name-update-text-c); /* Container with update */
 }
 
 /* Hide the "started" and "stopped" text so that only
 the green arrow or red square shows on containers */
-#docker_view .outer:not(.folder-docker) .state {
+#docker_view .outer:not(.folder-docker) .state,
+#vm_view .outer:not(.folder-vm) .state {
   opacity: 0;
 }
+
 
 /*************************************************/
 /* EXPANDED FOLDER HEADER STYLES */
 /*************************************************/
-/* Add padding to the clickable area - builds on compressed styles */
-#docker_view .folder-showcase-outer[expanded="true"] .hand.folder-hand-docker {
+
+/* Add padding to the clickable area - classic layout only */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .hand.folder-hand-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .hand.folder-hand-vm {
   padding: 8px;
 }
 
-/* Expanded folder wrapper/header styles */
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker {
-  display: block;
+/* Expanded folder wrapper/header styles (classic layout only) */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .outer.folder-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .outer.folder-vm {
+  display: block !important;
   float: none;
   padding: 8px;
   border: 1px solid var(--exfold-header-brdr-c);
@@ -145,15 +203,18 @@ the green arrow or red square shows on containers */
 }
 
 /* Folder Icon in Expanded Header */
-#docker_view .folder-showcase-outer[expanded="true"] img.folder-img-docker {
+#docker_view .folder-showcase-outer[expanded="true"] img.folder-img-docker,
+#vm_view .folder-showcase-outer[expanded="true"] img.folder-img-vm {
   /* Default icon size */
   width: var(--exfold-logo-size);
   height: var(--exfold-logo-size);
-  /* Desaturate docker folder icons */
-  filter: saturate(var(--folder-logo-saturation));
+  /* Desaturate docker folder icons (Docker & VM) */
+  filter: saturate(var(--exfold-logo-saturation));
 }
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker:hover img.folder-img-docker {
-  /* Saturate docker folder icons */
+
+#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker:hover img.folder-img-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .outer.folder-vm:hover img.folder-img-vm {
+  /* Saturate docker folder icons (Docker & VM) */
   filter: saturate(var(--exfold-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--exfold-logo-size-hov));
@@ -161,30 +222,41 @@ the green arrow or red square shows on containers */
 
 /* Set a height on the folder-name/text area to the same
 height of the icon - builds on compressed styles */
-#docker_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker {
+#docker_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-vm {
   height: var(--exfold-logo-size);
+}
+
+/* Classic layout: offset text for absolutely-positioned icon */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .inner.folder-inner-vm {
   margin-left: calc(var(--exfold-logo-size) + 7px);
 }
 
 /* Font for the folder name */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker {
+#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .folder-appname-vm {
   font-size: var(--exfold-foldername-text-size);
   font-weight: var(--exfold-foldername-text-weight);
   color: var(--exfold-foldername-text-c);
 }
-#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker.blue-text {
+
+#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker.blue-text,
+#vm_view .folder-showcase-outer[expanded="true"] .folder-appname-vm.blue-text {
   color: var(--exfold-foldername-updatetext-c);
 }
 
 /* Font for the container name inside a folder */
-#docker_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-docker) {
+#docker_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-docker),
+#vm_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-vm) {
   font-size: var(--exfold-contname-text-size);
   font-weight: var(--exfold-contname-text-weight);
   color: var(--exfold-contname-text-c);
 }
 
-/* Down arrow icon */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-docker::after {
+/* Down arrow icon (classic layout only, hidden when collapse toggle is active) */
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-docker::after,
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-vm::after {
   position: absolute;
   content: "\f0d7";
   display: block;
@@ -193,4 +265,6 @@ height of the icon - builds on compressed styles */
   right: 1rem;
   bottom: 0;
 }
-/*************************************************/
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .fv3-expanded-tab::after {
+  content: none;
+}

--- a/urgray-theme/04-table.docker.css
+++ b/urgray-theme/04-table.docker.css
@@ -1,20 +1,4 @@
 /*************************************************/
-/* CONTAINER LOGO ICON HOVER EFFECTS */
-/*************************************************/
-.folder-preview-wrapper img {
-  /* Desaturate docker container icons */
-  filter: saturate(var(--container-logo-saturation));
-  /* Add a transition for smooth scaling */
-  transition: transform 0.3s ease;
-}
-.folder-preview-wrapper:hover img {
-  /* Saturate docker container icons - Values above 1 will further saturate */
-  filter: saturate(var(--container-logo-saturation-hov));
-  /* Scale the image on hover */
-  transform: scale(var(--container-logo-size-hov));
-}
-
-/*************************************************/
 /* BASICS */
 /*************************************************/
 /* Apply border-box to all elements inside the docker table */
@@ -71,7 +55,7 @@
   color: var(--accent-blue-text-c);
 }
 
-/* Autostart switches */
+/* Autostart switches *//*
 #docker_containers .switch-button-background.checked,
 .preview-status .switch-button-background.checked {
   background-color: var(--cscheme-interface-passed);
@@ -80,12 +64,19 @@
 .preview-status .switch-button-label.on {
   color: var(--cscheme-interface-passed);
 }
-
+*/
 /*************************************************/
 /* FOLDER NAME AREA */
 /*************************************************/
 .folder .folder-name {
-  width: var(--folderbox-width);
+  min-width: var(--fv3-folder-name-min-width);
+  max-width: var(--fv3-folder-name-max-width);
+}
+/* Prevent folder icon from being clipped when scaled on hover */
+td.folder-name .folder-outer {
+  overflow: visible;
+  white-space: nowrap;
+  width: auto;
 }
 /* Wrapper around folder icon, name, and toggle */
 .folder .folder-name-sub {
@@ -97,12 +88,12 @@
   height: var(--folderbox-height);
   display: flex;
   align-items: center;
+  overflow: hidden;
 }
-.folder .folder-outer {
-  display: block;
-  height: var(--folder-logo-size);
+.outer.folder-outer {
+  display: inline-flex !important;
+  align-items: center !important;
   margin-bottom: 0;
-  width: calc(var(--folderbox-width) - 25px);
 }
 /* Folder image */
 .folder-outer img.img {
@@ -110,15 +101,15 @@
   height: var(--folder-logo-size);
   margin-right: var(--folder-logo-mrgright);
   /* Desaturate folder icons - Or as specified in vars */
-  filter: saturate(var(--folder-logo-saturation));
-  /* Add a transition for smooth scaling */
-  transition: transform 0.3s ease;
+    filter: saturate(var(--folder-logo-saturation));
+    /* Add a transition for smooth scaling */
+    transition: transform 0.3s ease;
 }
 .folder-outer:hover img.img {
   /* Saturate folder icons - Or as specified in vars */
-  filter: saturate(var(--folder-logo-saturation-hov));
-  /* Scale the image on hover */
-  transform: scale(var(--folder-logo-size-hov));
+    filter: saturate(var(--folder-logo-saturation-hov));
+    /* Scale the image on hover */
+    transform: scale(var(--folder-logo-size-hov));
 }
 /* Folder name text */
 .folder-outer .folder-appname {
@@ -126,8 +117,24 @@
   font-weight: var(--folder-name-text-weight);
 }
 /* Folder toggle open button */
-button.folder-dropwdown {
+button.folder-dropdown {
   float: none;
+  margin-left: auto;
+  color: var(--folder-button-text-c);
+  border: none;
+  background: var(--folder-button-background);
+  background-size: var(--folder-button-background-size);
+  transition: transform 0.3s ease, color 0.3s ease;
+}
+button.folder-dropdown:hover {
+  color: var(--folder-button-text-c-hov);
+  background: var(--folder-button-background-hov);
+  /* Scale the button on hover */
+  transform: scale(var(--folder-button-size-hov));
+}
+/* Small "press button" effect */
+button.folder-dropdown:active {
+  transform: scale(var(--folder-button-size-act));
 }
 /* Version column */
 .folder .updatecolumn {
@@ -137,6 +144,7 @@ button.folder-dropwdown {
 .outer.folder-outer .state {
   font-size: var(--folder-startstop-text-size);
   margin-left: var(--folder-startstop-text-mrgleft);
+  color: var(--cscheme-foreline2);
 }
 
 /*************************************************/
@@ -161,9 +169,20 @@ button.folder-dropwdown {
 /* Vertical lines between containers - if enabled */
 .folder-preview .folder-preview-divider {
   float: none;
-  height: var(--container-logo-size);
-  margin: var(--container-logo-mrgtopbottom) 5px var(--container-logo-mrgtopbottom) 10px;
+  height: 70%;
+  margin: 0 5px 0 10px;
+  align-self: center;
   border: 1px solid var(--folderpreview-brdr-c) !important;
+}
+.folder-preview.fv3-overflow-scroll .folder-preview-divider:not(:last-child) {
+  height: auto;
+  align-self: stretch;
+  margin-top: var(--container-logo-mrgtopbottom);
+}
+.folder-preview.fv3-overflow-expand .folder-preview-divider:not(:last-child) {
+  height: var(--container-logo-size);
+  margin-top: var(--container-logo-mrgtopbottom);
+  align-self: flex-start;
 }
 
 /*************************************************/
@@ -204,11 +223,49 @@ button.folder-dropwdown {
   margin-left: var(--container-startstop-text-mrgleft);
 }
 
+/*************************************************/
+/* EXPANDED / SCROLL PREVIEW MODES */
+/*************************************************/
+.folder .folder-preview.fv3-overflow-expand {
+  height: auto;
+  min-height: var(--folderpreview-height);
+  max-height: none;
+  padding-bottom: var(--container-logo-mrgtopbottom);
+}
+.folder:has(.folder-preview.fv3-overflow-expand) .folder-name-sub {
+  height: 100%;
+}
+.folder .folder-preview.fv3-overflow-scroll {
+  flex-wrap: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+}
+.folder-preview.fv3-overflow-scroll .folder-preview-wrapper {
+  flex-shrink: 0;
+}
+.folder-preview.fv3-overflow-scroll::-webkit-scrollbar {
+  height: 6px;
+  background: transparent;
+}
+.folder-preview.fv3-overflow-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 3px;
+}
+.folder-preview.fv3-overflow-scroll:hover::-webkit-scrollbar-thumb {
+  background: rgba(255, 140, 47, 0.5);
+}
+.folder .folder-preview.expanded {
+  height: auto;
+  max-height: none;
+}
+
+/****** Give more space for containers *******/
 /* Autostart column */
 #docker_containers th.nine {
-  width: 110px;
+  width: 0px; /*110px;*/
   padding: 0;
 }
+
 
 /*************************************************/
 /* EXPANDED FOLDER AND NO FOLDER CONTAINER ROW */
@@ -222,8 +279,8 @@ button.folder-dropwdown {
 
 /* Container name text */
 #docker_containers .inner:not(.folder-inner) .appname {
-  font-size: 1.4rem;
-  font-weight: bold;
+  font-size: var(--container-name-text-size);
+  font-weight: var(--container-name-text-weight);
 }
 
 /* Wait form on autostart containers */

--- a/urgray-theme/04-table.docker.css
+++ b/urgray-theme/04-table.docker.css
@@ -163,7 +163,7 @@ button.folder-dropdown:active {
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
   height: var(--folderpreview-height);
-  align-items: start;
+  align-items: center;
 }
 
 /* Vertical lines between containers - if enabled */
@@ -192,7 +192,7 @@ button.folder-dropdown:active {
 .folder-preview .folder-preview-wrapper {
   float: none;
   margin-left: var(--container-logo-mrgleft);
-  margin-top: var(--container-logo-mrgtopbottom);
+  margin-top: 4px;
   height: auto;
 }
 /* Container image */

--- a/urgray-theme/04-table.docker.css
+++ b/urgray-theme/04-table.docker.css
@@ -162,7 +162,8 @@ button.folder-dropdown:active {
   border-style: solid !important;
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
-  height: var(--folderpreview-height);
+  height: 100%;
+  min-height: var(--folderpreview-height);
   align-items: center;
 }
 

--- a/urgray-theme/04-table.docker.css
+++ b/urgray-theme/04-table.docker.css
@@ -289,3 +289,25 @@ button.folder-dropdown:active {
   display: block;
   margin-left: 10px;
 }
+
+/*************************************************/
+/* MOBILE / NARROW SCREEN                        */
+/*************************************************/
+@media (max-width: 768px) {
+  .folder-preview .folder-preview-divider {
+    float: none;
+    height: 70%;
+    margin: 0;
+    align-self: center;
+  }
+  .folder-preview.fv3-overflow-scroll .folder-preview-divider:not(:last-child) {
+    height: 36px;
+    margin-top: 10px;
+    align-self: flex-start;
+  }
+  .folder-preview.fv3-overflow-expand .folder-preview-divider:not(:last-child) {
+    height: 42px;
+    margin-top: 12px;
+    align-self: flex-start;
+  }
+}

--- a/urgray-theme/04-table.vm.css
+++ b/urgray-theme/04-table.vm.css
@@ -157,7 +157,7 @@ button.folder-dropdown:active {
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
   height: var(--folderpreview-height);
-  align-items: start;
+  align-items: center;
 }
 
 /* Vertical lines between containers - if enabled */
@@ -186,7 +186,7 @@ button.folder-dropdown:active {
 .folder-preview .folder-preview-wrapper {
   float: none;
   margin-left: var(--container-logo-mrgleft);
-  margin-top: var(--container-logo-mrgtopbottom);
+  margin-top: 4px;
   height: auto;
 }
 /* Container image */

--- a/urgray-theme/04-table.vm.css
+++ b/urgray-theme/04-table.vm.css
@@ -156,7 +156,8 @@ button.folder-dropdown:active {
   border-style: solid !important;
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
-  height: var(--folderpreview-height);
+  height: 100%;
+  min-height: var(--folderpreview-height);
   align-items: center;
 }
 

--- a/urgray-theme/04-table.vm.css
+++ b/urgray-theme/04-table.vm.css
@@ -282,3 +282,25 @@ button.folder-dropdown:active {
   display: block;
   margin-left: 10px;
 }
+
+/*************************************************/
+/* MOBILE / NARROW SCREEN                        */
+/*************************************************/
+@media (max-width: 768px) {
+  .folder-preview .folder-preview-divider {
+    float: none;
+    height: 70%;
+    margin: 0;
+    align-self: center;
+  }
+  .folder-preview.fv3-overflow-scroll .folder-preview-divider:not(:last-child) {
+    height: 36px;
+    margin-top: 10px;
+    align-self: flex-start;
+  }
+  .folder-preview.fv3-overflow-expand .folder-preview-divider:not(:last-child) {
+    height: 42px;
+    margin-top: 12px;
+    align-self: flex-start;
+  }
+}

--- a/urgray-theme/04-table.vm.css
+++ b/urgray-theme/04-table.vm.css
@@ -1,66 +1,63 @@
 /*************************************************/
 /* BASICS */
 /*************************************************/
-/* Apply border-box to all elements inside the docker table */
-#docker_containers,
-#docker_containers * {
+/* Apply border-box to all elements inside the vm table */
+#kvm_table,
+#kvm_table * {
   box-sizing: border-box;
 }
 
-/* Table row colors */
-#docker_containers.tablesorter {
-  background-color: var(--row-base-bg-c);
-}
-#docker_containers.tablesorter tbody tr:nth-child(even) {
-  background-color: var(--row-even-bg-c);
+#kvm_table .folder-name,
+#kvm_table .folder-outer {
+  width: auto;
 }
 
 /* Style all links that are not container tools */
-#docker_containers :not(.folder-element-custom-btn) > a,
-#docker_containers :not(.folder-element-custom-btn) > a:link,
-#docker_containers :not(.folder-element-custom-btn) > a:visited {
+#kvm_table :not(.folder-element-custom-btn) > a,
+#kvm_table :not(.folder-element-custom-btn) > a:link,
+#kvm_table :not(.folder-element-custom-btn) > a:visited {
   color: var(--cscheme-link);
   text-decoration: none;
 }
-#docker_containers :not(.folder-element-custom-btn) > a:hover {
+#kvm_table :not(.folder-element-custom-btn) > a:hover {
   color: var(--cscheme-linkhov);
   text-decoration: none;
 }
 
 /* Style all container names with updates available */
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text,
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:link,
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:visited {
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text,
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:link,
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:visited {
   color: var(--container-name-update-text-c);
   text-decoration: none;
   font-weight: bold;
 }
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:hover {
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:hover {
   color: var(--container-name-update-texthov-c);
   text-decoration: none;
   font-weight: bold;
 }
 
 /* Warning and Passed Text */
-#docker_containers .orange-text,
-#docker_containers .warning {
+#kvm_table .orange-text,
+#kvm_table .warning {
   color: var(--warn-orange-text-c);
 }
-#docker_containers .green,
-#docker_containers .green-text,
-#docker_containers .passed {
+#kvm_table .green,
+#kvm_table .green-text,
+#kvm_table .passed {
   color: var(--pass-green-text-c);
 }
-#docker_containers .blue-text {
+#kvm_table .blue-text {
   color: var(--accent-blue-text-c);
 }
 
 /* Autostart switches *//*
-#docker_containers .switch-button-background.checked,
+#kvm_table .switch-button-background.checked,
 .preview-status .switch-button-background.checked {
   background-color: var(--cscheme-interface-passed);
 }
-#docker_containers .switch-button-label.on,
+#kvm_table .switch-button-label.on,
 .preview-status .switch-button-label.on {
   color: var(--cscheme-interface-passed);
 }
@@ -75,8 +72,6 @@
 /* Prevent folder icon from being clipped when scaled on hover */
 td.folder-name .folder-outer {
   overflow: visible;
-  white-space: nowrap;
-  width: auto;
 }
 /* Wrapper around folder icon, name, and toggle */
 .folder .folder-name-sub {
@@ -119,7 +114,6 @@ td.folder-name .folder-outer {
 /* Folder toggle open button */
 button.folder-dropdown {
   float: none;
-  margin-left: auto;
   color: var(--folder-button-text-c);
   border: none;
   background: var(--folder-button-background);
@@ -200,14 +194,14 @@ button.folder-dropdown:active {
   width: var(--container-logo-size);
   height: var(--container-logo-size);
   margin-right: 5px;
-  /* Desaturate docker container icons - Or as specified in vars */
+  /* Desaturate vm container icons - Or as specified in vars */
   filter: saturate(var(--container-logo-saturation));
   /* Add a transition for smooth scaling */
   transition: transform 0.3s ease;
 }
 /* Container image hover */
 .folder-preview-wrapper:hover .outer img.img {
-  /* Saturate docker container icons - Or as specified in vars */
+  /* Saturate vm container icons - Or as specified in vars */
   filter: saturate(var(--container-logo-saturation-hov));
   /* Scale the image on hover */
   transform: scale(var(--container-logo-size-hov));
@@ -261,30 +255,29 @@ button.folder-dropdown:active {
 
 /****** Give more space for containers *******/
 /* Autostart column */
-#docker_containers th.nine {
+#kvm_table th.nine {
   width: 0px; /*110px;*/
   padding: 0;
 }
-
 
 /*************************************************/
 /* EXPANDED FOLDER AND NO FOLDER CONTAINER ROW */
 /*************************************************/
 /* Cell for container name */
-#docker_containers .folder-element .ct-name,
-#docker_containers .ct-name:not(.folder-name) {
+#kvm_table .folder-element .ct-name,
+#kvm_table .ct-name:not(.folder-name) {
   width: auto !important;
   padding: 8px 20px 8px var(--container-nofold-namebox-padding-left) !important;
 }
 
 /* Container name text */
-#docker_containers .inner:not(.folder-inner) .appname {
+#kvm_table .inner:not(.folder-inner) .appname {
   font-size: var(--container-name-text-size);
   font-weight: var(--container-name-text-weight);
 }
 
 /* Wait form on autostart containers */
-#docker_containers tr.sortable:not(.folder) td:nth-child(7) span:last-of-type {
+#kvm_table tr.sortable:not(.folder) td:nth-child(7) span:last-of-type {
   float: none !important;
   display: block;
   margin-left: 10px;

--- a/urgray-theme/06-icons.dashboard.css
+++ b/urgray-theme/06-icons.dashboard.css
@@ -1,72 +1,114 @@
 /*************************************************/
 /* STARTED/STOPPED ICON SIZES */
 /*************************************************/
+
 /* Folder Status */
-#docker_view .outer.folder-docker i::before {
+#docker_view .outer.folder-docker i::before,
+#vm_view .outer.folder-vm i::before {
   font-size: var(--folder-status-size);
 }
+
 /* Expanded Folder Status */
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker i::before {
+#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker i::before,
+#vm_view .folder-showcase-outer[expanded="true"] .outer.folder-vm i::before {
   font-size: var(--exfold-status-size);
 }
+
 /* Container Status */
-#docker_view .outer.folder-element-docker i::before {
+#docker_view .outer.folder-element-docker i::before,
+#vm_view .outer.folder-element-vm i::before {
   font-size: var(--container-status-size);
 }
+
 /* Container Autostart Status */
-#docker_view .outer.folder-element-docker.autostart i::before {
+#docker_view .outer.folder-element-docker.autostart i::before,
+#vm_view .outer.folder-element-vm.autostart i::before {
   font-size: var(--container-atostart-status-size);
 }
+
 
 /*************************************************/
 /* DEFAULT STARTED/STOPPED ICONS */
 /*************************************************/
+
 /* Started Icon */
-#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before {
+#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before,
+#vm_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before {
   content: var(--container-started-icon);
   color: var(--container-started-icon-c);
 }
+
 /* Stopped Icon */
-#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before {
+#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before,
+#vm_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before {
   content: var(--container-stopped-icon);
   color: var(--container-stopped-icon-c);
 }
+
 /* Spin Icon - Started */
-#docker_view .outer i.started.fa-spin::before {
+#docker_view .outer i.started.fa-spin::before,
+#vm_view .outer i.started.fa-spin::before {
   content: var(--container-spin-started-icon);
   color: var(--container-spin-started-icon-c);
 }
+
 /* Spin Icon - Stopped */
-#docker_view .outer i.stopped.fa-spin::before {
+#docker_view .outer i.stopped.fa-spin::before,
+#vm_view .outer i.stopped.fa-spin::before {
   content: var(--container-spin-stopped-icon);
   color: var(--container-spin-stopped-icon-c);
 }
 
+
 /*************************************************/
 /* AUTOSTART ICONS */
 /*************************************************/
+
 /* Container Icons */
-#docker_view .outer:not(.folder-docker).autostart.started i:not(.fa-spin)::before {
+#docker_view .outer:not(.folder-docker).autostart.started i:not(.fa-spin)::before,
+#vm_view .outer:not(.folder-vm).autostart.started i:not(.fa-spin)::before {
   content: var(--container-autostart-started-icon); /* Replace the green triangle with a different icon */
   color: var(--container-autostart-started-icon-c);
 }
-#docker_view .outer:not(.folder-docker).autostart.stopped i:not(.fa-spin)::before {
+
+#docker_view .outer:not(.folder-docker).autostart.stopped i:not(.fa-spin)::before,
+#vm_view .outer:not(.folder-vm).autostart.stopped i:not(.fa-spin)::before {
   content: var(--container-autostart-stopped-icon); /* Replace the red square with a different icon */
   color: var(--container-autostart-stopped-icon-c);
 }
 
+/* Spin Icon - Started */
+#docker_view .outer:not(.folder-docker).autostart.started i.fa-spin::before,
+#vm_view .outer:not(.folder-vm).autostart.started i.fa-spin::before {
+  content: var(--container-spin-started-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-started-icon-c);
+}
+
+/* Spin Icon - Stopped */
+#docker_view .outer:not(.folder-docker).autostart.stopped i.fa-spin::before,
+#vm_view .outer:not(.folder-vm).autostart.stopped i.fa-spin::before {
+  content: var(--container-spin-stopped-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-stopped-icon-c); /* Set spin color of stopped autostart container */
+}
+
+
 /* Folder Icons */
 /* Replace the default container status icon with an icon
 denoting presence of autostart containers */
-#docker_view .outer.folder-docker.autostart-full i::before {
+#docker_view .outer.folder-docker.autostart-full i::before,
+#vm_view .outer.folder-vm.autostart-full i::before {
   content: var(--folder-autostart-full-icon);
   color: var(--folder-autostart-full-icon-c); /* Green color when all autostart containers are started */
 }
-#docker_view .outer.folder-docker.autostart-partial i::before {
+
+#docker_view .outer.folder-docker.autostart-partial i::before,
+#vm_view .outer.folder-vm.autostart-partial i::before {
   content: var(--folder-autostart-partial-icon);
   color: var(--folder-autostart-partial-icon-c); /* Orange when some autostart containers are started */
 }
-#docker_view .outer.folder-docker.autostart-off i::before {
+
+#docker_view .outer.folder-docker.autostart-off i::before,
+#vm_view .outer.folder-vm.autostart-off i::before {
   content: var(--folder-autostart-off-icon);
   color: var(--folder-autostart-off-icon-c); /* Red when no autostart containers are started */
 }

--- a/urgray-theme/06-icons.docker-vm.css
+++ b/urgray-theme/06-icons.docker-vm.css
@@ -125,6 +125,18 @@
   content: var(--container-autostart-stopped-icon); /* Replace the red square with a different icon */
   color: var(--container-autostart-stopped-icon-c);
 }
+
+/* Container autostart Spin Icon - Started */
+.outer:not(.folder-outer).autostart i.started.fa-spin::before {
+  content: var(--container-spin-started-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-started-icon-c);
+}
+/* Container autostart Spin Icon - Stopped */
+.outer:not(.folder-outer).autostart i.stopped.fa-spin::before {
+  content: var(--container-spin-stopped-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-stopped-icon-c);
+}
+
 /* Folder Icons */
 /* Replace the folder's default ontainer status icon with an icon
 denoting presence of autostart containers */

--- a/urgray-theme/08-fv3-overrides.dashboard-docker-vm.css
+++ b/urgray-theme/08-fv3-overrides.dashboard-docker-vm.css
@@ -1,0 +1,111 @@
+/*************************************************/
+/* FV3 PLUGIN VARIABLE OVERRIDES */
+/* Override FolderView3 built-in CSS variables    */
+/* to match this theme's color palette            */
+/*************************************************/
+:root {
+  /* Graph colors */
+  --folder-view3-graph-cpu: var(--cscheme-cpu);
+  --folder-view3-graph-mem: var(--cscheme-mem);
+
+  /* Tooltip / Advanced Preview theme colors */
+  --fv3-surface-tint: rgba(200, 200, 200, 0.08);
+  --fv3-hover-bg: rgba(200, 200, 200, 0.15);
+  --fv3-border: 1px solid rgba(200, 200, 200, 0.2);
+
+  /* Dashboard: Inset layout */
+  --fv3-inset-border-color: var(--cscheme-foreline3);
+  --fv3-inset-fill: var(--cscheme-foreline4);
+  --fv3-inset-showcase-border: var(--cscheme-foreline4);
+  --fv3-inset-showcase-fill: rgba(27, 29, 27, 0.4);
+  --fv3-inset-bg: transparent;
+  --fv3-showcase-bg: transparent;
+
+  /* Dashboard: Embossed layout */
+  --fv3-embossed-border: var(--cscheme-foreline3);
+  --fv3-embossed-accent: var(--cscheme-accent1);
+  --fv3-embossed-bg: transparent;
+  --fv3-embossed-shadow: none;
+  --fv3-embossed-inner-border: var(--cscheme-foreline4);
+  --fv3-embossed-inner-bg: rgba(200, 200, 200, 0.05);
+}
+
+/*************************************************/
+/* COLLAPSE TOGGLE BUTTON — styled as the down arrow */
+/*************************************************/
+button.fv3-collapse-toggle {
+  z-index: 51;
+  position: absolute;
+  right: 1rem;
+  bottom: 0;
+  top: auto;
+  left: auto;
+  transform: none;
+  width: auto;
+  height: auto;
+  max-width: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: inherit;
+  font-size: 3rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+button.fv3-collapse-toggle:hover {
+  background: transparent;
+  border: none;
+  color: var(--cscheme-accent1);
+  transform: none;
+}
+button.fv3-collapse-toggle:active {
+  transform: none;
+}
+/* Accordion/Embossed: static positioning next to folder name */
+.fv3-layout-accordion button.fv3-collapse-toggle,
+.fv3-layout-embossed button.fv3-collapse-toggle {
+  position: static;
+  font-size: 1.2rem;
+  margin-left: 10px;
+  vertical-align: middle;
+}
+/* Force chevron-up icon, overriding icon theme rules */
+#docker_view .outer.folder-docker button.fv3-collapse-toggle i::before,
+#docker_view .outer.folder-element-docker button.fv3-collapse-toggle i::before,
+#vm_view .outer.folder-vm button.fv3-collapse-toggle i::before,
+#vm_view .outer.folder-element-vm button.fv3-collapse-toggle i::before {
+  content: "\f077";
+  font-family: FontAwesome;
+  color: inherit;
+  font-size: inherit;
+}
+
+/*************************************************/
+/* ACCORDION / FULLWIDTH / INSET / EMBOSSED      */
+/* Extra padding for larger custom theme icons    */
+/*************************************************/
+.fv3-layout-accordion .folder-showcase:not(:empty) {
+  border-color: var(--cscheme-foreline4);
+  border-left-color: var(--cscheme-accent1);
+  padding: 12px;
+  overflow: visible;
+}
+
+.fv3-fullwidth-panel {
+  border-color: var(--cscheme-foreline4);
+  border-left-color: var(--cscheme-accent1);
+  padding: 12px;
+}
+
+.fv3-layout-inset .folder-showcase:not(:empty) {
+  padding: 12px;
+  overflow: visible;
+}
+
+.fv3-layout-embossed .folder-showcase:not(:empty) {
+  padding: 12px;
+  overflow: visible;
+}

--- a/urgray-theme/README.md
+++ b/urgray-theme/README.md
@@ -1,6 +1,6 @@
 # unRAID Gray Theme
 
-_Use of this theme requires FolderView version **2023.10.04**_
+_Use of this theme requires FolderView3 version **2026.03.23.3** or later_
 
 Based on color and style from the out-of-box **Gray** theme in **unRAID**.
 Dashboard and Docker table have been fully themed with easy-to-access variables that even those with limited CSS skills can edit and tweak.
@@ -9,21 +9,23 @@ Dashboard and Docker table have been fully themed with easy-to-access variables 
 
 File naming determines load order. _Do not change the naming of these files unless you know what you're doing._
 
-- **01-colors.dashboard-docker.css:** _Color scheme file. Stores all colors used by other dashboard and docker page CSS files._
+- **01-colors.dashboard-docker-vm.css:** _Color scheme file. Stores all colors used by dashboard, docker, and VM page CSS files._
 - **02-vars.dashboard.css:** _Variables used by other dashboard CSS files. Most editing can be done in this file._
-- **02-vars.docker.css:** _Variables used by other docker page CSS files. Most editing can be done in this file._
+- **02-vars.docker-vm.css:** _Variables used by other docker and VM page CSS files. Most editing can be done in this file._
 - **03-vars-icons.dashboard.css:** _Variables pertaining specifically to icons on the dashboard._
-- **03-vars-icons.docker.css:** _Variables pertaining specifically to icons on the docker page._
+- **03-vars-icons.docker-vm.css:** _Variables pertaining specifically to icons on the docker and VM pages._
 - **04-dash.dashboard.css:** _Main CSS selectors file for the dashboard._
 - **04-table.docker.css:** _Main CSS selectors file for the docker page._
+- **04-table.vm.css:** _Main CSS selectors file for the VM page._
 - **05-tableadv.docker.css:** _Selectors and rules pertaining to elements added with the Advanced View switch._
 - **06-icons.dashboard.css:** _Selectors and rules specific to icons on the dashboard._
-- **06-icons.docker.css:** _Selectors and rules specific to icons on the docker page._
+- **06-icons.docker-vm.css:** _Selectors and rules specific to icons on the docker and VM pages._
 - **07-advcontext.docker.css:** _Variables, selectors, and rules specific to the Advanced Context Menu._
+- **08-fv3-overrides.dashboard-docker-vm.css:** _FolderView3 plugin variable overrides and layout adjustments for accordion, fullwidth, inset, and embossed modes._
 
 ## Sample Images
 
-_Icons in these images are desaturated by the CSS rules and saturate on hover. These settings are easily disabled by changing the variable values in the **02-vars.dashboard.css** and **02-vars.docker.css** files._
+_Icons in these images are desaturated by the CSS rules and saturate on hover. These settings are easily disabled by changing the variable values in the **02-vars.dashboard.css** and **02-vars.docker-vm.css** files._
 
 ### Example:
 

--- a/urwhite-theme/01-colors.dashboard-docker-vm.css
+++ b/urwhite-theme/01-colors.dashboard-docker-vm.css
@@ -7,10 +7,17 @@ like https://htmlcolorcodes.com/color-picker/ */
 /*************************************************/
 :root {
   --cscheme-accent1: #f0582c;
+  --cscheme-accent1-dark: #d44a22;
   --cscheme-accent2: #3e6dba;
   --cscheme-accent3: #4f8a10;
+  --cscheme-accent4: #256f92;
+  --cscheme-accent5: #00BCD4;
+  --cscheme-accent6: #9575CD;
 
+  --cscheme-foreline0: #1c1b1b;
   --cscheme-foreline1: #1c1b1b;
+  --cscheme-foreline1-light: #3a3a3a;
+  --cscheme-foreline1-dark: #606060;
   --cscheme-foreline2: #4e4e4e;
   --cscheme-foreline3: #a8a8a8;
   --cscheme-foreline4: #dcdcdc;
@@ -18,11 +25,17 @@ like https://htmlcolorcodes.com/color-picker/ */
   --cscheme-backfill2: #f2f2f2;
   --cscheme-backfill3: #f5f5f5;
   --cscheme-backfill4: #ffffff;
+  --cscheme-cpu: #00BCD4; /* CPU accent color Graph Line */
+  --cscheme-mem: #673AB7; /* Mem accent color Graph Line */
 
   --cscheme-interface-alert: #f0000c;
+  --cscheme-interface-alert2: #fb039a;
   --cscheme-interface-warn: #f0582c;
+  --cscheme-interface-warn2: #FFEB3B;
   --cscheme-interface-attention: #d6ff20;
+  --cscheme-interface-attention2: #FFEB3B;
   --cscheme-interface-passed: #4caf50;
+  --cscheme-interface-passed2: #4caf50;
   --cscheme-interface-accent: #2cabe3;
 
   --cscheme-link: #486dba; /* Text links within the docker table */

--- a/urwhite-theme/02-vars.dashboard.css
+++ b/urwhite-theme/02-vars.dashboard.css
@@ -10,9 +10,9 @@
 
   /* Folder icon */
   --folder-logo-size: 32px;
-  --folder-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --folder-logo-saturation: 0; /* Initial color depth for folder icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --folder-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --folder-logo-size-hov: 1.2;
+  --folder-logo-saturation: 0;
+  --folder-logo-saturation-hov: 1;
 
   /* Default container name text size and weight */
   --container-name-text-size: 1.3rem;
@@ -22,9 +22,12 @@
 
   /* Container icon */
   --container-logo-size: 32px;
-  --container-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --container-logo-saturation: 0; /* Initial color depth for container icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --container-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --container-logo-size-hov: 1.2;
+  --container-logo-saturation: 0;
+  --container-logo-saturation-hov: 1;
+
+  /* Override FV3 inset fill to match classic expanded header grey */
+  --fv3-inset-fill: var(--cscheme-foreline4);
 
   /****** EXPANDED FOLDER STYLES ******/
   --exfold-header-brdr-c: var(--cscheme-foreline4); /* Border color for the header */
@@ -38,12 +41,12 @@
 
   /* Folder icon in expanded folder header */
   --exfold-logo-size: 48px;
-  --exfold-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --exfold-logo-saturation: 0; /* Initial color depth for folder icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --exfold-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --exfold-logo-size-hov: 1.2;
+  --exfold-logo-saturation: 0;
+  --exfold-logo-saturation-hov: 1;
 
   /* Container within an expanded folder */
-  --exfold-contname-text-c: inherit; /* Color for the container name when inside a folder */
-  --exfold-contname-text-size: 1.4rem; /* Size for the container name when inside a folder */
-  --exfold-contname-text-weight: bold; /* Weight for the container name when inside a folder */
+  --exfold-contname-text-c: inherit;
+  --exfold-contname-text-size: 1.4rem;
+  --exfold-contname-text-weight: bold;
 }

--- a/urwhite-theme/02-vars.docker-vm.css
+++ b/urwhite-theme/02-vars.docker-vm.css
@@ -4,15 +4,21 @@
 :root {
   /* Passed/Warning/Green/Orange Text */
   --warn-orange-text-c: var(--cscheme-interface-warn);
-  --pass-green-text-c: var(--cscheme-interface-good);
+  --pass-green-text-c: var(--cscheme-interface-passed);
   --accent-blue-text-c: var(--cscheme-interface-accent);
 
   /* Table Rows */
   --row-base-bg-c: var(--cscheme-backfill4);
   --row-even-bg-c: var(--cscheme-backfill2);
 
+  /* Table Rows VMs Colors */
+  --fv3-row-bg: var(--row-base-bg-c);
+  --fv3-row-alt-bg: var(--row-even-bg-c);
+
   /* Folder Name/Logo Area */
-  --folderbox-width: 250px; /* May need to be increased if --folder-name-text-size is too big */
+  --fv3-folder-name-min-width: 250px;
+  --fv3-folder-name-max-width: none;
+  --folderbox-width: var(--fv3-folder-name-min-width); /* May need to be increased if --folder-name-text-size is too big */
   --folderbox-height: calc(var(--folder-logo-size) + (var(--folderbox-padding-topbottom) * 2) + (var(--folderbox-brdr-width-topbottom) * 2));
   --folderbox-padding-topbottom: 10px;
   --folderbox-padding-leftright: 10px;
@@ -22,14 +28,22 @@
   --folderbox-brdr-width-right: 3px;
 
   --folder-logo-size: 40px;
-  --folder-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --folder-logo-saturation: 0; /* Initial color depth for folder icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --folder-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --folder-logo-size-hov: 1.2;
+  --folder-logo-saturation: 0;
+  --folder-logo-saturation-hov: 1;
   --folder-logo-mrgright: 8px;
   --folder-name-text-size: 1.5rem;
   --folder-name-text-weight: bold;
-  --folder-startstop-text-size: 1.2rem; /* 0 to hide */
-  --folder-startstop-text-mrgleft: 7px; /* 0 to hide */
+  --folder-startstop-text-size: 1.2rem;
+  --folder-startstop-text-mrgleft: 7px;
+
+  --folder-button-size-hov: 1.08;
+  --folder-button-size-act: 0.98;
+  --folder-button-background: linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1)) 0 0 no-repeat, linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1)) 0 100% no-repeat, linear-gradient(0deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1-dark)) 0 100% no-repeat, linear-gradient(0deg, var(--cscheme-foreline1) 0, var(--cscheme-foreline1)) 100% 100% no-repeat;
+  --folder-button-background-size: 100% 2px, 100% 2px, 2px 100%, 2px 100%;
+  --folder-button-background-hov: linear-gradient(90deg, var(--cscheme-foreline1-dark) 0, var(--cscheme-foreline1));
+  --folder-button-text-c: var(--cscheme-foreline1);
+  --folder-button-text-c-hov: var(--cscheme-foreline0);
 
   /* Folder/Container Preview Row */
   --folderpreview-height: calc(var(--container-logo-size) + (var(--container-logo-mrgtopbottom) * 2) + (var(--folderpreview-brdr-width-topbottom) * 2));
@@ -40,17 +54,17 @@
 
   /* Container */
   --container-logo-size: 38px;
-  --container-logo-size-hov: 1.2; /* Changes logo size on hover - Used in transform/scale rule - 1 is 100%, 1.2 is 120%, 2 is 200%, etc. */
-  --container-logo-saturation: 0; /* Initial color depth for container icons - 0 is fully-desaturated (grayscale), 1 is default saturation */
-  --container-logo-saturation-hov: 1; /* 1 is 100% or default color depth - Values above 1 will saturate beyond default colors, Example: 4 = 400% */
+  --container-logo-size-hov: 1.2;
+  --container-logo-saturation: 0;
+  --container-logo-saturation-hov: 1;
   --container-logo-mrgtopbottom: 10px;
   --container-logo-mrgleft: 10px;
   --container-name-text-size: 1.3rem;
   --container-name-text-weight: bold;
   --container-name-update-text-c: var(--cscheme-cont-update);
   --container-name-update-texthov-c: var(--cscheme-cont-updatehov);
-  --container-startstop-text-size: 0; /* default 1.1rem */
-  --container-startstop-text-mrgleft: 0; /* default 7px */
+  --container-startstop-text-size: 0;
+  --container-startstop-text-mrgleft: 0;
   --container-nofold-namebox-padding-left: calc(6px + var(--folderbox-padding-leftright) + var(--folderbox-brdr-width-left));
 }
 /*************************************************/

--- a/urwhite-theme/03-vars-icons.docker-vm.css
+++ b/urwhite-theme/03-vars-icons.docker-vm.css
@@ -1,5 +1,5 @@
 /*************************************************/
-/* VARIABLES FOR ICONS IN DOCKER TABLE - 
+/* VARIABLES FOR ICONS IN DOCKER TABLE -
 Change these settings to your preference */
 /*************************************************/
 /* See https://fontawesome.com/icons for icons.

--- a/urwhite-theme/04-dash.dashboard.css
+++ b/urwhite-theme/04-dash.dashboard.css
@@ -1,39 +1,54 @@
 /*************************************************/
 /* FOLDER & CONTAINER LOGO ICON HOVER EFFECTS */
 /*************************************************/
+
 /* ALL Folder and Container Icons (also affects expanded header icon) */
-#docker_view .outer img {
+#docker_view .outer img,
+#vm_view .outer img {
   /* Add a transition for smooth scaling */
   transition: transform 0.3s ease;
 }
+
 /* ************ Folder Icon (Compressed Only) ************ */
-#docker_view .outer.folder-docker img {
+#docker_view .outer.folder-docker img,
+#vm_view .outer.folder-vm img {
   /* Default icon size */
   height: var(--folder-logo-size);
   width: var(--folder-logo-size);
-  /* Desaturate docker folder icons */
+  /* Desaturate docker folder icons (Docker & VM) */
   filter: saturate(var(--folder-logo-saturation));
 }
-#docker_view .outer.folder-docker:hover img {
-  /* Saturate docker folder icons */
+
+#docker_view .outer.folder-docker:hover img,
+#vm_view .outer.folder-vm:hover img {
+  /* Saturate docker folder icons (Docker & VM) */
   filter: saturate(var(--folder-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--folder-logo-size-hov));
 }
+
 /* ************ Container Icon ************ */
-#docker_view .outer.folder-element-docker img {
+#docker_view .outer.folder-element-docker img,
+#vm_view .outer.folder-element-vm img {
   /* Default icon size */
   height: var(--container-logo-size);
   width: var(--container-logo-size);
-  /* Desaturate docker container icons */
+  /* Desaturate docker container icons (Docker & VM) */
   filter: saturate(var(--container-logo-saturation));
 }
-#docker_view .outer.folder-element-docker:hover img {
-  /* Saturate docker container icons */
+
+#docker_view .outer.folder-element-docker:hover img,
+#vm_view .outer.folder-element-vm:hover img {
+  /* Saturate docker container icons (Docker & VM) */
   filter: saturate(var(--container-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--container-logo-size-hov));
 }
+
+
+/*************************************************/
+/* SHARED LAYOUT RULES */
+/*************************************************/
 
 /* Apply border-box to all elements inside the docker and vm panes */
 #docker_view *,
@@ -42,19 +57,19 @@
 }
 
 /* Add a padding left to the entire docker and vm icon area
-- this compensates for the expanded folder header */
-#docker_view tr:nth-child(2) td,
-#vm_view tr:nth-child(2) td {
+- this compensates for the expanded folder header (classic only) */
+#docker_view tr:nth-child(2) td.fv3-layout-classic,
+#vm_view tr:nth-child(2) td.fv3-layout-classic {
   padding-left: 20px;
   padding-bottom: 10px;
 }
 
-/* Expand the clickable area of folders and containers
-to the full width of the wrapper */
-#docker_view .hand {
+/* Expand the clickable area of folders and containers (classic only) */
+.fv3-layout-classic .hand {
   position: absolute;
   z-index: 50;
-  display: inline-block;
+  display: flex !important;
+  align-items: center !important;
   left: 0;
   right: 0;
   top: 0;
@@ -62,80 +77,123 @@ to the full width of the wrapper */
   padding: 0;
 }
 
-/* Set a height on the name/text area of
-the folders and containers to the same height of the icon */
-#docker_view .inner {
+/* Set a min-height on the name/text area of
+the folders and containers to the same height of the icon (classic only) */
+.fv3-layout-classic .inner {
   display: inline-block;
-  height: var(--container-logo-size);
+  min-height: var(--container-logo-size);
   margin-left: calc(var(--container-logo-size) + 6px);
 }
 
-/* Compressed folder wrapper and docker container wrapper styles */
-#docker_view .outer {
-  position: relative; /* Needed for absolute positioning of child elements */
-  display: inline-block;
-  background-color: transparent;
+/* Compressed folder wrapper and docker container wrapper styles (classic only) */
+#docker_view .fv3-layout-classic .outer,
+#vm_view .fv3-layout-classic .outer {
+  position: relative;
 }
 
-/* Expanded folder outer wrapper styles */
-#docker_view .folder-showcase-outer[expanded="true"] {
+/* Transparent background and vertical icon centering for all dashboard tiles */
+#docker_view .outer,
+#vm_view .outer {
+  background-color: transparent;
+  display: inline-flex !important;
+  align-items: center !important;
+}
+
+/* Restore block display for expanded folder headers (all layouts) */
+.folder-showcase-outer[expanded="true"] .outer.folder-docker,
+.folder-showcase-outer[expanded="true"] .outer.folder-vm {
+  display: block !important;
+}
+
+
+/*************************************************/
+/* EXPANDED FOLDER WRAPPER STYLES */
+/*************************************************/
+
+/* Allow full folder names on expanded folders (classic only — other layouts use FV3 truncation) */
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .fv3-folder-appname {
+  max-width: none;
+  overflow: visible;
+  white-space: nowrap;
+}
+
+/* Expanded folder outer wrapper styles (classic layout only — other layouts keep FV3 structure) */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"],
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"],
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] {
   float: left;
   display: block;
-  margin-left: -10px; /* Overcome 20px container padding-left by giving
-                      expanded folder a negative left margin */
-  width: calc(100% + 10px); /* Add 10px to the width to overcome negative margin */
+  margin-left: -10px;
+  width: calc(100% + 10px);
   border-radius: 10px;
   border-width: 1px;
   border-style: solid;
   border-color: var(--exfold-drawer-brdr-c);
   background-color: var(--exfold-drawer-bg-c);
 }
-#docker_view .folder-showcase-outer[expanded="true"]:not(:last-child) {
-  margin-bottom: 20px; /* Only apply 20px margin if it's NOT the last element */
+
+.fv3-layout-classic .folder-showcase-outer[expanded="true"]:not(:last-child) {
+  margin-bottom: 20px;
 }
 
 /* Child docker container icons wrapper "drawer" styles */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-showcase {
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-showcase {
   float: left;
   display: block;
   padding: 0 20px;
 }
 
+
+/*************************************************/
+/* TEXT STYLES */
+/*************************************************/
+
 /* Compressed Folder text */
-#docker_view .inner.folder-inner-docker {
+#docker_view .inner.folder-inner-docker,
+#vm_view .inner.folder-inner-vm {
   font-size: var(--folder-name-text-size);
   font-weight: var(--folder-name-text-weight);
 }
-#docker_view .inner.folder-inner-docker .blue-text {
+
+#docker_view .inner.folder-inner-docker .blue-text,
+#vm_view .inner.folder-inner-vm .blue-text {
   color: var(--folder-name-update-text-c); /* Folder with update */
 }
 
 /* Container text */
-#docker_view .inner:not(.folder-inner-docker) {
+#docker_view .inner:not(.folder-inner-docker),
+#vm_view .inner:not(.folder-inner-vm) {
   font-size: var(--container-name-text-size);
   font-weight: var(--container-name-text-weight);
 }
-#docker_view .inner:not(.folder-inner-docker) .blue-text {
+
+#docker_view .inner:not(.folder-inner-docker) .blue-text,
+#vm_view .inner:not(.folder-inner-vm) .blue-text {
   color: var(--container-name-update-text-c); /* Container with update */
 }
 
 /* Hide the "started" and "stopped" text so that only
 the green arrow or red square shows on containers */
-#docker_view .outer:not(.folder-docker) .state {
+#docker_view .outer:not(.folder-docker) .state,
+#vm_view .outer:not(.folder-vm) .state {
   opacity: 0;
 }
+
 
 /*************************************************/
 /* EXPANDED FOLDER HEADER STYLES */
 /*************************************************/
-/* Add padding to the clickable area - builds on compressed styles */
-#docker_view .folder-showcase-outer[expanded="true"] .hand.folder-hand-docker {
+
+/* Add padding to the clickable area - classic layout only */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .hand.folder-hand-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .hand.folder-hand-vm {
   padding: 8px;
 }
 
-/* Expanded folder wrapper/header styles */
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker {
-  display: block;
+/* Expanded folder wrapper/header styles (classic layout only) */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .outer.folder-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .outer.folder-vm {
+  display: block !important;
   float: none;
   padding: 8px;
   border: 1px solid var(--exfold-header-brdr-c);
@@ -145,15 +203,18 @@ the green arrow or red square shows on containers */
 }
 
 /* Folder Icon in Expanded Header */
-#docker_view .folder-showcase-outer[expanded="true"] img.folder-img-docker {
+#docker_view .folder-showcase-outer[expanded="true"] img.folder-img-docker,
+#vm_view .folder-showcase-outer[expanded="true"] img.folder-img-vm {
   /* Default icon size */
   width: var(--exfold-logo-size);
   height: var(--exfold-logo-size);
-  /* Desaturate docker folder icons */
-  filter: saturate(var(--folder-logo-saturation));
+  /* Desaturate docker folder icons (Docker & VM) */
+  filter: saturate(var(--exfold-logo-saturation));
 }
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker:hover img.folder-img-docker {
-  /* Saturate docker folder icons */
+
+#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker:hover img.folder-img-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .outer.folder-vm:hover img.folder-img-vm {
+  /* Saturate docker folder icons (Docker & VM) */
   filter: saturate(var(--exfold-logo-saturation-hov));
   /* Scale the icon on hover */
   transform: scale(var(--exfold-logo-size-hov));
@@ -161,30 +222,41 @@ the green arrow or red square shows on containers */
 
 /* Set a height on the folder-name/text area to the same
 height of the icon - builds on compressed styles */
-#docker_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker {
+#docker_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .inner.folder-inner-vm {
   height: var(--exfold-logo-size);
+}
+
+/* Classic layout: offset text for absolutely-positioned icon */
+#docker_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .inner.folder-inner-docker,
+#vm_view .fv3-layout-classic .folder-showcase-outer[expanded="true"] .inner.folder-inner-vm {
   margin-left: calc(var(--exfold-logo-size) + 7px);
 }
 
 /* Font for the folder name */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker {
+#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker,
+#vm_view .folder-showcase-outer[expanded="true"] .folder-appname-vm {
   font-size: var(--exfold-foldername-text-size);
   font-weight: var(--exfold-foldername-text-weight);
   color: var(--exfold-foldername-text-c);
 }
-#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker.blue-text {
+
+#docker_view .folder-showcase-outer[expanded="true"] .folder-appname-docker.blue-text,
+#vm_view .folder-showcase-outer[expanded="true"] .folder-appname-vm.blue-text {
   color: var(--exfold-foldername-updatetext-c);
 }
 
 /* Font for the container name inside a folder */
-#docker_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-docker) {
+#docker_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-docker),
+#vm_view .folder-showcase-outer[expanded="true"] .inner:not(.folder-inner-vm) {
   font-size: var(--exfold-contname-text-size);
   font-weight: var(--exfold-contname-text-weight);
   color: var(--exfold-contname-text-c);
 }
 
-/* Down arrow icon */
-#docker_view .folder-showcase-outer[expanded="true"] .folder-docker::after {
+/* Down arrow icon (classic layout only, hidden when collapse toggle is active) */
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-docker::after,
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .folder-vm::after {
   position: absolute;
   content: "\f0d7";
   display: block;
@@ -193,4 +265,6 @@ height of the icon - builds on compressed styles */
   right: 1rem;
   bottom: 0;
 }
-/*************************************************/
+.fv3-layout-classic .folder-showcase-outer[expanded="true"] .fv3-expanded-tab::after {
+  content: none;
+}

--- a/urwhite-theme/04-table.docker.css
+++ b/urwhite-theme/04-table.docker.css
@@ -163,7 +163,7 @@ button.folder-dropdown:active {
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
   height: var(--folderpreview-height);
-  align-items: start;
+  align-items: center;
 }
 
 /* Vertical lines between containers - if enabled */
@@ -192,7 +192,7 @@ button.folder-dropdown:active {
 .folder-preview .folder-preview-wrapper {
   float: none;
   margin-left: var(--container-logo-mrgleft);
-  margin-top: var(--container-logo-mrgtopbottom);
+  margin-top: 4px;
   height: auto;
 }
 /* Container image */

--- a/urwhite-theme/04-table.docker.css
+++ b/urwhite-theme/04-table.docker.css
@@ -162,7 +162,8 @@ button.folder-dropdown:active {
   border-style: solid !important;
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
-  height: var(--folderpreview-height);
+  height: 100%;
+  min-height: var(--folderpreview-height);
   align-items: center;
 }
 

--- a/urwhite-theme/04-table.docker.css
+++ b/urwhite-theme/04-table.docker.css
@@ -55,7 +55,7 @@
   color: var(--accent-blue-text-c);
 }
 
-/* Autostart switches */
+/* Autostart switches *//*
 #docker_containers .switch-button-background.checked,
 .preview-status .switch-button-background.checked {
   background-color: var(--cscheme-interface-passed);
@@ -64,12 +64,19 @@
 .preview-status .switch-button-label.on {
   color: var(--cscheme-interface-passed);
 }
-
+*/
 /*************************************************/
 /* FOLDER NAME AREA */
 /*************************************************/
 .folder .folder-name {
-  width: var(--folderbox-width);
+  min-width: var(--fv3-folder-name-min-width);
+  max-width: var(--fv3-folder-name-max-width);
+}
+/* Prevent folder icon from being clipped when scaled on hover */
+td.folder-name .folder-outer {
+  overflow: visible;
+  white-space: nowrap;
+  width: auto;
 }
 /* Wrapper around folder icon, name, and toggle */
 .folder .folder-name-sub {
@@ -81,12 +88,12 @@
   height: var(--folderbox-height);
   display: flex;
   align-items: center;
+  overflow: hidden;
 }
-.folder .folder-outer {
-  display: block;
-  height: var(--folder-logo-size);
+.outer.folder-outer {
+  display: inline-flex !important;
+  align-items: center !important;
   margin-bottom: 0;
-  width: calc(var(--folderbox-width) - 25px);
 }
 /* Folder image */
 .folder-outer img.img {
@@ -94,15 +101,15 @@
   height: var(--folder-logo-size);
   margin-right: var(--folder-logo-mrgright);
   /* Desaturate folder icons - Or as specified in vars */
-  filter: saturate(var(--folder-logo-saturation));
-  /* Add a transition for smooth scaling */
-  transition: transform 0.3s ease;
+    filter: saturate(var(--folder-logo-saturation));
+    /* Add a transition for smooth scaling */
+    transition: transform 0.3s ease;
 }
 .folder-outer:hover img.img {
   /* Saturate folder icons - Or as specified in vars */
-  filter: saturate(var(--folder-logo-saturation-hov));
-  /* Scale the image on hover */
-  transform: scale(var(--folder-logo-size-hov));
+    filter: saturate(var(--folder-logo-saturation-hov));
+    /* Scale the image on hover */
+    transform: scale(var(--folder-logo-size-hov));
 }
 /* Folder name text */
 .folder-outer .folder-appname {
@@ -110,8 +117,24 @@
   font-weight: var(--folder-name-text-weight);
 }
 /* Folder toggle open button */
-button.folder-dropwdown {
+button.folder-dropdown {
   float: none;
+  margin-left: auto;
+  color: var(--folder-button-text-c);
+  border: none;
+  background: var(--folder-button-background);
+  background-size: var(--folder-button-background-size);
+  transition: transform 0.3s ease, color 0.3s ease;
+}
+button.folder-dropdown:hover {
+  color: var(--folder-button-text-c-hov);
+  background: var(--folder-button-background-hov);
+  /* Scale the button on hover */
+  transform: scale(var(--folder-button-size-hov));
+}
+/* Small "press button" effect */
+button.folder-dropdown:active {
+  transform: scale(var(--folder-button-size-act));
 }
 /* Version column */
 .folder .updatecolumn {
@@ -121,6 +144,7 @@ button.folder-dropwdown {
 .outer.folder-outer .state {
   font-size: var(--folder-startstop-text-size);
   margin-left: var(--folder-startstop-text-mrgleft);
+  color: var(--cscheme-foreline2);
 }
 
 /*************************************************/
@@ -145,9 +169,20 @@ button.folder-dropwdown {
 /* Vertical lines between containers - if enabled */
 .folder-preview .folder-preview-divider {
   float: none;
-  height: var(--container-logo-size);
-  margin: var(--container-logo-mrgtopbottom) 5px var(--container-logo-mrgtopbottom) 10px;
+  height: 70%;
+  margin: 0 5px 0 10px;
+  align-self: center;
   border: 1px solid var(--folderpreview-brdr-c) !important;
+}
+.folder-preview.fv3-overflow-scroll .folder-preview-divider:not(:last-child) {
+  height: auto;
+  align-self: stretch;
+  margin-top: var(--container-logo-mrgtopbottom);
+}
+.folder-preview.fv3-overflow-expand .folder-preview-divider:not(:last-child) {
+  height: var(--container-logo-size);
+  margin-top: var(--container-logo-mrgtopbottom);
+  align-self: flex-start;
 }
 
 /*************************************************/
@@ -188,11 +223,49 @@ button.folder-dropwdown {
   margin-left: var(--container-startstop-text-mrgleft);
 }
 
+/*************************************************/
+/* EXPANDED / SCROLL PREVIEW MODES */
+/*************************************************/
+.folder .folder-preview.fv3-overflow-expand {
+  height: auto;
+  min-height: var(--folderpreview-height);
+  max-height: none;
+  padding-bottom: var(--container-logo-mrgtopbottom);
+}
+.folder:has(.folder-preview.fv3-overflow-expand) .folder-name-sub {
+  height: 100%;
+}
+.folder .folder-preview.fv3-overflow-scroll {
+  flex-wrap: nowrap;
+  overflow-x: scroll;
+  overflow-y: hidden;
+}
+.folder-preview.fv3-overflow-scroll .folder-preview-wrapper {
+  flex-shrink: 0;
+}
+.folder-preview.fv3-overflow-scroll::-webkit-scrollbar {
+  height: 6px;
+  background: transparent;
+}
+.folder-preview.fv3-overflow-scroll::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 3px;
+}
+.folder-preview.fv3-overflow-scroll:hover::-webkit-scrollbar-thumb {
+  background: rgba(255, 140, 47, 0.5);
+}
+.folder .folder-preview.expanded {
+  height: auto;
+  max-height: none;
+}
+
+/****** Give more space for containers *******/
 /* Autostart column */
 #docker_containers th.nine {
-  width: 110px;
+  width: 0px; /*110px;*/
   padding: 0;
 }
+
 
 /*************************************************/
 /* EXPANDED FOLDER AND NO FOLDER CONTAINER ROW */
@@ -206,8 +279,8 @@ button.folder-dropwdown {
 
 /* Container name text */
 #docker_containers .inner:not(.folder-inner) .appname {
-  font-size: 1.4rem;
-  font-weight: bold;
+  font-size: var(--container-name-text-size);
+  font-weight: var(--container-name-text-weight);
 }
 
 /* Wait form on autostart containers */

--- a/urwhite-theme/04-table.docker.css
+++ b/urwhite-theme/04-table.docker.css
@@ -289,3 +289,25 @@ button.folder-dropdown:active {
   display: block;
   margin-left: 10px;
 }
+
+/*************************************************/
+/* MOBILE / NARROW SCREEN                        */
+/*************************************************/
+@media (max-width: 768px) {
+  .folder-preview .folder-preview-divider {
+    float: none;
+    height: 70%;
+    margin: 0;
+    align-self: center;
+  }
+  .folder-preview.fv3-overflow-scroll .folder-preview-divider:not(:last-child) {
+    height: 36px;
+    margin-top: 10px;
+    align-self: flex-start;
+  }
+  .folder-preview.fv3-overflow-expand .folder-preview-divider:not(:last-child) {
+    height: 42px;
+    margin-top: 12px;
+    align-self: flex-start;
+  }
+}

--- a/urwhite-theme/04-table.vm.css
+++ b/urwhite-theme/04-table.vm.css
@@ -157,7 +157,7 @@ button.folder-dropdown:active {
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
   height: var(--folderpreview-height);
-  align-items: start;
+  align-items: center;
 }
 
 /* Vertical lines between containers - if enabled */
@@ -186,7 +186,7 @@ button.folder-dropdown:active {
 .folder-preview .folder-preview-wrapper {
   float: none;
   margin-left: var(--container-logo-mrgleft);
-  margin-top: var(--container-logo-mrgtopbottom);
+  margin-top: 4px;
   height: auto;
 }
 /* Container image */

--- a/urwhite-theme/04-table.vm.css
+++ b/urwhite-theme/04-table.vm.css
@@ -156,7 +156,8 @@ button.folder-dropdown:active {
   border-style: solid !important;
   border-color: var(--folderpreview-brdr-c) !important;
   border-width: var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-right) var(--folderpreview-brdr-width-topbottom) var(--folderpreview-brdr-width-left) !important;
-  height: var(--folderpreview-height);
+  height: 100%;
+  min-height: var(--folderpreview-height);
   align-items: center;
 }
 

--- a/urwhite-theme/04-table.vm.css
+++ b/urwhite-theme/04-table.vm.css
@@ -282,3 +282,25 @@ button.folder-dropdown:active {
   display: block;
   margin-left: 10px;
 }
+
+/*************************************************/
+/* MOBILE / NARROW SCREEN                        */
+/*************************************************/
+@media (max-width: 768px) {
+  .folder-preview .folder-preview-divider {
+    float: none;
+    height: 70%;
+    margin: 0;
+    align-self: center;
+  }
+  .folder-preview.fv3-overflow-scroll .folder-preview-divider:not(:last-child) {
+    height: 36px;
+    margin-top: 10px;
+    align-self: flex-start;
+  }
+  .folder-preview.fv3-overflow-expand .folder-preview-divider:not(:last-child) {
+    height: 42px;
+    margin-top: 12px;
+    align-self: flex-start;
+  }
+}

--- a/urwhite-theme/04-table.vm.css
+++ b/urwhite-theme/04-table.vm.css
@@ -1,66 +1,63 @@
 /*************************************************/
 /* BASICS */
 /*************************************************/
-/* Apply border-box to all elements inside the docker table */
-#docker_containers,
-#docker_containers * {
+/* Apply border-box to all elements inside the vm table */
+#kvm_table,
+#kvm_table * {
   box-sizing: border-box;
 }
 
-/* Table row colors */
-#docker_containers.tablesorter {
-  background-color: var(--row-base-bg-c);
-}
-#docker_containers.tablesorter tbody tr:nth-child(even) {
-  background-color: var(--row-even-bg-c);
+#kvm_table .folder-name,
+#kvm_table .folder-outer {
+  width: auto;
 }
 
 /* Style all links that are not container tools */
-#docker_containers :not(.folder-element-custom-btn) > a,
-#docker_containers :not(.folder-element-custom-btn) > a:link,
-#docker_containers :not(.folder-element-custom-btn) > a:visited {
+#kvm_table :not(.folder-element-custom-btn) > a,
+#kvm_table :not(.folder-element-custom-btn) > a:link,
+#kvm_table :not(.folder-element-custom-btn) > a:visited {
   color: var(--cscheme-link);
   text-decoration: none;
 }
-#docker_containers :not(.folder-element-custom-btn) > a:hover {
+#kvm_table :not(.folder-element-custom-btn) > a:hover {
   color: var(--cscheme-linkhov);
   text-decoration: none;
 }
 
 /* Style all container names with updates available */
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text,
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:link,
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:visited {
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text,
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:link,
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:visited {
   color: var(--container-name-update-text-c);
   text-decoration: none;
   font-weight: bold;
 }
-#docker_containers :not(.folder-element-custom-btn) > a.orange-text:hover {
+#kvm_table :not(.folder-element-custom-btn) > a.orange-text:hover {
   color: var(--container-name-update-texthov-c);
   text-decoration: none;
   font-weight: bold;
 }
 
 /* Warning and Passed Text */
-#docker_containers .orange-text,
-#docker_containers .warning {
+#kvm_table .orange-text,
+#kvm_table .warning {
   color: var(--warn-orange-text-c);
 }
-#docker_containers .green,
-#docker_containers .green-text,
-#docker_containers .passed {
+#kvm_table .green,
+#kvm_table .green-text,
+#kvm_table .passed {
   color: var(--pass-green-text-c);
 }
-#docker_containers .blue-text {
+#kvm_table .blue-text {
   color: var(--accent-blue-text-c);
 }
 
 /* Autostart switches *//*
-#docker_containers .switch-button-background.checked,
+#kvm_table .switch-button-background.checked,
 .preview-status .switch-button-background.checked {
   background-color: var(--cscheme-interface-passed);
 }
-#docker_containers .switch-button-label.on,
+#kvm_table .switch-button-label.on,
 .preview-status .switch-button-label.on {
   color: var(--cscheme-interface-passed);
 }
@@ -75,8 +72,6 @@
 /* Prevent folder icon from being clipped when scaled on hover */
 td.folder-name .folder-outer {
   overflow: visible;
-  white-space: nowrap;
-  width: auto;
 }
 /* Wrapper around folder icon, name, and toggle */
 .folder .folder-name-sub {
@@ -119,7 +114,6 @@ td.folder-name .folder-outer {
 /* Folder toggle open button */
 button.folder-dropdown {
   float: none;
-  margin-left: auto;
   color: var(--folder-button-text-c);
   border: none;
   background: var(--folder-button-background);
@@ -200,14 +194,14 @@ button.folder-dropdown:active {
   width: var(--container-logo-size);
   height: var(--container-logo-size);
   margin-right: 5px;
-  /* Desaturate docker container icons - Or as specified in vars */
+  /* Desaturate vm container icons - Or as specified in vars */
   filter: saturate(var(--container-logo-saturation));
   /* Add a transition for smooth scaling */
   transition: transform 0.3s ease;
 }
 /* Container image hover */
 .folder-preview-wrapper:hover .outer img.img {
-  /* Saturate docker container icons - Or as specified in vars */
+  /* Saturate vm container icons - Or as specified in vars */
   filter: saturate(var(--container-logo-saturation-hov));
   /* Scale the image on hover */
   transform: scale(var(--container-logo-size-hov));
@@ -261,30 +255,29 @@ button.folder-dropdown:active {
 
 /****** Give more space for containers *******/
 /* Autostart column */
-#docker_containers th.nine {
+#kvm_table th.nine {
   width: 0px; /*110px;*/
   padding: 0;
 }
-
 
 /*************************************************/
 /* EXPANDED FOLDER AND NO FOLDER CONTAINER ROW */
 /*************************************************/
 /* Cell for container name */
-#docker_containers .folder-element .ct-name,
-#docker_containers .ct-name:not(.folder-name) {
+#kvm_table .folder-element .ct-name,
+#kvm_table .ct-name:not(.folder-name) {
   width: auto !important;
   padding: 8px 20px 8px var(--container-nofold-namebox-padding-left) !important;
 }
 
 /* Container name text */
-#docker_containers .inner:not(.folder-inner) .appname {
+#kvm_table .inner:not(.folder-inner) .appname {
   font-size: var(--container-name-text-size);
   font-weight: var(--container-name-text-weight);
 }
 
 /* Wait form on autostart containers */
-#docker_containers tr.sortable:not(.folder) td:nth-child(7) span:last-of-type {
+#kvm_table tr.sortable:not(.folder) td:nth-child(7) span:last-of-type {
   float: none !important;
   display: block;
   margin-left: 10px;

--- a/urwhite-theme/06-icons.dashboard.css
+++ b/urwhite-theme/06-icons.dashboard.css
@@ -1,72 +1,114 @@
 /*************************************************/
 /* STARTED/STOPPED ICON SIZES */
 /*************************************************/
+
 /* Folder Status */
-#docker_view .outer.folder-docker i::before {
+#docker_view .outer.folder-docker i::before,
+#vm_view .outer.folder-vm i::before {
   font-size: var(--folder-status-size);
 }
+
 /* Expanded Folder Status */
-#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker i::before {
+#docker_view .folder-showcase-outer[expanded="true"] .outer.folder-docker i::before,
+#vm_view .folder-showcase-outer[expanded="true"] .outer.folder-vm i::before {
   font-size: var(--exfold-status-size);
 }
+
 /* Container Status */
-#docker_view .outer.folder-element-docker i::before {
+#docker_view .outer.folder-element-docker i::before,
+#vm_view .outer.folder-element-vm i::before {
   font-size: var(--container-status-size);
 }
+
 /* Container Autostart Status */
-#docker_view .outer.folder-element-docker.autostart i::before {
+#docker_view .outer.folder-element-docker.autostart i::before,
+#vm_view .outer.folder-element-vm.autostart i::before {
   font-size: var(--container-atostart-status-size);
 }
+
 
 /*************************************************/
 /* DEFAULT STARTED/STOPPED ICONS */
 /*************************************************/
+
 /* Started Icon */
-#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before {
+#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before,
+#vm_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).started i:not(.fa-spin)::before {
   content: var(--container-started-icon);
   color: var(--container-started-icon-c);
 }
+
 /* Stopped Icon */
-#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before {
+#docker_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before,
+#vm_view .outer:not(.autostart, .autostart-full, .autostart-partial, .autostart-off).stopped i:not(.fa-spin)::before {
   content: var(--container-stopped-icon);
   color: var(--container-stopped-icon-c);
 }
+
 /* Spin Icon - Started */
-#docker_view .outer i.started.fa-spin::before {
+#docker_view .outer i.started.fa-spin::before,
+#vm_view .outer i.started.fa-spin::before {
   content: var(--container-spin-started-icon);
   color: var(--container-spin-started-icon-c);
 }
+
 /* Spin Icon - Stopped */
-#docker_view .outer i.stopped.fa-spin::before {
+#docker_view .outer i.stopped.fa-spin::before,
+#vm_view .outer i.stopped.fa-spin::before {
   content: var(--container-spin-stopped-icon);
   color: var(--container-spin-stopped-icon-c);
 }
 
+
 /*************************************************/
 /* AUTOSTART ICONS */
 /*************************************************/
+
 /* Container Icons */
-#docker_view .outer:not(.folder-docker).autostart.started i:not(.fa-spin)::before {
+#docker_view .outer:not(.folder-docker).autostart.started i:not(.fa-spin)::before,
+#vm_view .outer:not(.folder-vm).autostart.started i:not(.fa-spin)::before {
   content: var(--container-autostart-started-icon); /* Replace the green triangle with a different icon */
   color: var(--container-autostart-started-icon-c);
 }
-#docker_view .outer:not(.folder-docker).autostart.stopped i:not(.fa-spin)::before {
+
+#docker_view .outer:not(.folder-docker).autostart.stopped i:not(.fa-spin)::before,
+#vm_view .outer:not(.folder-vm).autostart.stopped i:not(.fa-spin)::before {
   content: var(--container-autostart-stopped-icon); /* Replace the red square with a different icon */
   color: var(--container-autostart-stopped-icon-c);
 }
 
+/* Spin Icon - Started */
+#docker_view .outer:not(.folder-docker).autostart.started i.fa-spin::before,
+#vm_view .outer:not(.folder-vm).autostart.started i.fa-spin::before {
+  content: var(--container-spin-started-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-started-icon-c);
+}
+
+/* Spin Icon - Stopped */
+#docker_view .outer:not(.folder-docker).autostart.stopped i.fa-spin::before,
+#vm_view .outer:not(.folder-vm).autostart.stopped i.fa-spin::before {
+  content: var(--container-spin-stopped-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-stopped-icon-c); /* Set spin color of stopped autostart container */
+}
+
+
 /* Folder Icons */
 /* Replace the default container status icon with an icon
 denoting presence of autostart containers */
-#docker_view .outer.folder-docker.autostart-full i::before {
+#docker_view .outer.folder-docker.autostart-full i::before,
+#vm_view .outer.folder-vm.autostart-full i::before {
   content: var(--folder-autostart-full-icon);
   color: var(--folder-autostart-full-icon-c); /* Green color when all autostart containers are started */
 }
-#docker_view .outer.folder-docker.autostart-partial i::before {
+
+#docker_view .outer.folder-docker.autostart-partial i::before,
+#vm_view .outer.folder-vm.autostart-partial i::before {
   content: var(--folder-autostart-partial-icon);
   color: var(--folder-autostart-partial-icon-c); /* Orange when some autostart containers are started */
 }
-#docker_view .outer.folder-docker.autostart-off i::before {
+
+#docker_view .outer.folder-docker.autostart-off i::before,
+#vm_view .outer.folder-vm.autostart-off i::before {
   content: var(--folder-autostart-off-icon);
   color: var(--folder-autostart-off-icon-c); /* Red when no autostart containers are started */
 }

--- a/urwhite-theme/06-icons.docker-vm.css
+++ b/urwhite-theme/06-icons.docker-vm.css
@@ -125,6 +125,18 @@
   content: var(--container-autostart-stopped-icon); /* Replace the red square with a different icon */
   color: var(--container-autostart-stopped-icon-c);
 }
+
+/* Container autostart Spin Icon - Started */
+.outer:not(.folder-outer).autostart i.started.fa-spin::before {
+  content: var(--container-spin-started-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-started-icon-c);
+}
+/* Container autostart Spin Icon - Stopped */
+.outer:not(.folder-outer).autostart i.stopped.fa-spin::before {
+  content: var(--container-spin-stopped-icon); /* Replace the spinner with a different icon */
+  color: var(--container-autostart-stopped-icon-c);
+}
+
 /* Folder Icons */
 /* Replace the folder's default ontainer status icon with an icon
 denoting presence of autostart containers */

--- a/urwhite-theme/08-fv3-overrides.dashboard-docker-vm.css
+++ b/urwhite-theme/08-fv3-overrides.dashboard-docker-vm.css
@@ -1,0 +1,111 @@
+/*************************************************/
+/* FV3 PLUGIN VARIABLE OVERRIDES */
+/* Override FolderView3 built-in CSS variables    */
+/* to match this theme's color palette            */
+/*************************************************/
+:root {
+  /* Graph colors */
+  --folder-view3-graph-cpu: var(--cscheme-cpu);
+  --folder-view3-graph-mem: var(--cscheme-mem);
+
+  /* Tooltip / Advanced Preview theme colors */
+  --fv3-surface-tint: rgba(0, 0, 0, 0.04);
+  --fv3-hover-bg: rgba(0, 0, 0, 0.08);
+  --fv3-border: 1px solid rgba(0, 0, 0, 0.12);
+
+  /* Dashboard: Inset layout */
+  --fv3-inset-border-color: var(--cscheme-foreline3);
+  --fv3-inset-fill: var(--cscheme-foreline4);
+  --fv3-inset-showcase-border: var(--cscheme-foreline3);
+  --fv3-inset-showcase-fill: rgba(245, 245, 245, 0.5);
+  --fv3-inset-bg: transparent;
+  --fv3-showcase-bg: transparent;
+
+  /* Dashboard: Embossed layout */
+  --fv3-embossed-border: var(--cscheme-foreline3);
+  --fv3-embossed-accent: var(--cscheme-accent1);
+  --fv3-embossed-bg: transparent;
+  --fv3-embossed-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.06);
+  --fv3-embossed-inner-border: var(--cscheme-foreline3);
+  --fv3-embossed-inner-bg: rgba(0, 0, 0, 0.03);
+}
+
+/*************************************************/
+/* COLLAPSE TOGGLE BUTTON — styled as the down arrow */
+/*************************************************/
+button.fv3-collapse-toggle {
+  z-index: 51;
+  position: absolute;
+  right: 1rem;
+  bottom: 0;
+  top: auto;
+  left: auto;
+  transform: none;
+  width: auto;
+  height: auto;
+  max-width: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  color: inherit;
+  font-size: 3rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.3s ease;
+}
+button.fv3-collapse-toggle:hover {
+  background: transparent;
+  border: none;
+  color: var(--cscheme-accent1);
+  transform: none;
+}
+button.fv3-collapse-toggle:active {
+  transform: none;
+}
+/* Accordion/Embossed: static positioning next to folder name */
+.fv3-layout-accordion button.fv3-collapse-toggle,
+.fv3-layout-embossed button.fv3-collapse-toggle {
+  position: static;
+  font-size: 1.2rem;
+  margin-left: 10px;
+  vertical-align: middle;
+}
+/* Force chevron-up icon, overriding icon theme rules */
+#docker_view .outer.folder-docker button.fv3-collapse-toggle i::before,
+#docker_view .outer.folder-element-docker button.fv3-collapse-toggle i::before,
+#vm_view .outer.folder-vm button.fv3-collapse-toggle i::before,
+#vm_view .outer.folder-element-vm button.fv3-collapse-toggle i::before {
+  content: "\f077";
+  font-family: FontAwesome;
+  color: inherit;
+  font-size: inherit;
+}
+
+/*************************************************/
+/* ACCORDION / FULLWIDTH / INSET / EMBOSSED      */
+/* Extra padding for larger custom theme icons    */
+/*************************************************/
+.fv3-layout-accordion .folder-showcase:not(:empty) {
+  border-color: var(--cscheme-foreline3);
+  border-left-color: var(--cscheme-accent1);
+  padding: 12px;
+  overflow: visible;
+}
+
+.fv3-fullwidth-panel {
+  border-color: var(--cscheme-foreline3);
+  border-left-color: var(--cscheme-accent1);
+  padding: 12px;
+}
+
+.fv3-layout-inset .folder-showcase:not(:empty) {
+  padding: 12px;
+  overflow: visible;
+}
+
+.fv3-layout-embossed .folder-showcase:not(:empty) {
+  padding: 12px;
+  overflow: visible;
+}

--- a/urwhite-theme/README.md
+++ b/urwhite-theme/README.md
@@ -1,6 +1,6 @@
 # unRAID White Theme
 
-_Use of this theme requires FolderView version **2023.10.04**_
+_Use of this theme requires FolderView3 version **2026.03.23.3** or later_
 
 Based on color and style from the out-of-box **White** theme in **unRAID**.
 Dashboard and Docker table have been fully themed with easy-to-access variables that even those with limited CSS skills can edit and tweak.
@@ -9,21 +9,23 @@ Dashboard and Docker table have been fully themed with easy-to-access variables 
 
 File naming determines load order. _Do not change the naming of these files unless you know what you're doing._
 
-- **01-colors.dashboard-docker.css:** _Color scheme file. Stores all colors used by other dashboard and docker page CSS files._
+- **01-colors.dashboard-docker-vm.css:** _Color scheme file. Stores all colors used by dashboard, docker, and VM page CSS files._
 - **02-vars.dashboard.css:** _Variables used by other dashboard CSS files. Most editing can be done in this file._
-- **02-vars.docker.css:** _Variables used by other docker page CSS files. Most editing can be done in this file._
+- **02-vars.docker-vm.css:** _Variables used by other docker and VM page CSS files. Most editing can be done in this file._
 - **03-vars-icons.dashboard.css:** _Variables pertaining specifically to icons on the dashboard._
-- **03-vars-icons.docker.css:** _Variables pertaining specifically to icons on the docker page._
+- **03-vars-icons.docker-vm.css:** _Variables pertaining specifically to icons on the docker and VM pages._
 - **04-dash.dashboard.css:** _Main CSS selectors file for the dashboard._
 - **04-table.docker.css:** _Main CSS selectors file for the docker page._
+- **04-table.vm.css:** _Main CSS selectors file for the VM page._
 - **05-tableadv.docker.css:** _Selectors and rules pertaining to elements added with the Advanced View switch._
 - **06-icons.dashboard.css:** _Selectors and rules specific to icons on the dashboard._
-- **06-icons.docker.css:** _Selectors and rules specific to icons on the docker page._
+- **06-icons.docker-vm.css:** _Selectors and rules specific to icons on the docker and VM pages._
 - **07-advcontext.docker.css:** _Variables, selectors, and rules specific to the Advanced Context Menu._
+- **08-fv3-overrides.dashboard-docker-vm.css:** _FolderView3 plugin variable overrides and layout adjustments for accordion, fullwidth, inset, and embossed modes._
 
 ## Sample Images
 
-_Icons in these images are desaturated by the CSS rules and saturate on hover. These settings are easily disabled by changing the variable values in the **02-vars.dashboard.css** and **02-vars.docker.css** files._
+_Icons in these images are desaturated by the CSS rules and saturate on hover. These settings are easily disabled by changing the variable values in the **02-vars.dashboard.css** and **02-vars.docker-vm.css** files._
 
 ### Example:
 


### PR DESCRIPTION
## Summary

- Rename docker-only CSS files to docker-vm to support both Docker and VM pages
- Add VM table CSS files (`04-table.vm.css`) for all three themes
- Add FV3 override files (`08-fv3-overrides.dashboard-docker-vm.css`) for all themes
- Add dynamic folder name width with `--fv3-folder-name-min-width` and `--fv3-folder-name-max-width` CSS variables
- Scope dashboard selectors to `.fv3-layout-classic` for FV3 compatibility while preserving your classic dashboard look
- Add `#vm_view` selectors alongside `#docker_view` selectors for VM page support
- Add expanded/scroll preview overflow mode rules with custom scrollbar styling
- Add collapse toggle button styling for classic and accordion/embossed layouts
- Add support for FV3 layout modes: accordion, fullwidth, inset, and embossed
- Add new color variables needed by FV3 (cpu, mem, accent4-6, foreline variants)
- Fix `--pass-green-text-c` reference from undefined `--cscheme-interface-good` to `--cscheme-interface-passed`
- Update READMEs with new file listings and FV3 version requirement

## Details

This PR ports the FV3 structural/compatibility changes from [masterwishx/folder.view.custom.css#1](https://github.com/masterwishx/folder.view.custom.css/pull/1) to this upstream repo while **preserving all of your original color values, sizing preferences, and styling choices**.

Key structural changes:
- **File renames**: `*-docker.css` → `*-docker-vm.css` for files that now apply to both Docker and VM pages
- **New files**: `04-table.vm.css` (VM table layout), `08-fv3-overrides.dashboard-docker-vm.css` (FV3 variable overrides)
- **Dashboard scoping**: Selectors are scoped to `.fv3-layout-classic` so FV3's other layout modes (accordion, fullwidth, inset, embossed) work correctly
- **Folder name width**: Changed from fixed `width` to `min-width`/`max-width` for dynamic FV3 folder name sizing
- **Icon centering**: `.folder-outer` changed to `inline-flex` with `align-items: center` for proper icon vertical centering
- **Preview overflow**: Added support for FV3's scroll and expand preview modes

Requires FolderView3 version **2026.03.23.3** or later.

## Test plan

- [ ] Verify all three themes (black, gray, white) load correctly in unRAID with FolderView3
- [ ] Check that classic dashboard layout looks identical to before
- [ ] Test accordion, fullwidth, inset, and embossed layout modes
- [ ] Verify VM page styling works alongside Docker page styling
- [ ] Test scroll and expand preview overflow modes
- [ ] Verify folder name dynamic width works correctly
- [ ] Check that color values match your original preferences